### PR TITLE
toggle keyboard handler for custom editors

### DIFF
--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -2559,7 +2559,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     ]);
                 });
             }
-            focus(true);
+            focus();
             setOverlay(undefined);
 
             const [movX, movY] = movement;

--- a/packages/core/src/data-grid-overlay-editor/data-grid-overlay-editor.tsx
+++ b/packages/core/src/data-grid-overlay-editor/data-grid-overlay-editor.tsx
@@ -11,6 +11,7 @@ import {
     isInnerOnlyCell,
     isObjectEditorCallbackResult,
     Item,
+    KeyboardEventHandlingMode,
     ProvideEditorCallback,
     ProvideEditorCallbackResult,
     Rectangle,
@@ -115,8 +116,14 @@ const DataGridOverlayEditor: React.FunctionComponent<DataGridOverlayEditorProps>
         [onFinishEditing]
     );
 
+    const [keyboardEventHandlingMode, setKeyboardEventHandlingMode] = React.useState<KeyboardEventHandlingMode>("auto");
+
     const onKeyDown = React.useCallback(
         async (event: React.KeyboardEvent) => {
+            // if the mode is manual, no need to handle the keyboard events
+            if (keyboardEventHandlingMode === "manual") {
+                return;
+            }
             let save = false;
             if (event.key === "Escape") {
                 event.stopPropagation();
@@ -141,7 +148,7 @@ const DataGridOverlayEditor: React.FunctionComponent<DataGridOverlayEditorProps>
                 }
             }, 0);
         },
-        [onFinishEditing, tempValue]
+        [onFinishEditing, tempValue, keyboardEventHandlingMode]
     );
 
     const targetValue = tempValue ?? content;
@@ -172,6 +179,7 @@ const DataGridOverlayEditor: React.FunctionComponent<DataGridOverlayEditorProps>
             <CustomEditor
                 isHighlighted={highlight}
                 onChange={setTempValue}
+                setKeyboardEventHandlingMode={setKeyboardEventHandlingMode}
                 value={targetValue}
                 initialValue={initialValue}
                 onFinishedEditing={onEditorFinished}

--- a/packages/core/src/data-grid/data-grid-types.ts
+++ b/packages/core/src/data-grid/data-grid-types.ts
@@ -450,6 +450,8 @@ export interface BubbleCell extends BaseGridCell {
 /** @category Renderers */
 export type SelectionRange = number | readonly [number, number];
 
+export type KeyboardEventHandlingMode = "manual" | "auto";
+
 /** @category Renderers */
 export type ProvideEditorComponent<T extends InnerGridCell> = React.FunctionComponent<{
     readonly onChange: (newValue: T) => void;
@@ -463,6 +465,12 @@ export type ProvideEditorComponent<T extends InnerGridCell> = React.FunctionComp
     readonly target: Rectangle;
     readonly forceEditMode: boolean;
     readonly isValid?: boolean;
+    /**
+     * set the keyboard event handling mode
+     * "manual": glide will not handle the "Enter", "Tab" and "Escape" events
+     * "auto": glide will handle the "Enter", "Tab" and "Escape" events by appropriate actions
+     */
+    readonly setKeyboardEventHandlingMode: (mode: KeyboardEventHandlingMode) => void;
 }>;
 
 type ObjectEditorCallbackResult<T extends InnerGridCell> = {

--- a/packages/core/test/cells.test.tsx
+++ b/packages/core/test/cells.test.tsx
@@ -66,6 +66,7 @@ describe("Image cell", () => {
                 value={cell}
                 target={target}
                 forceEditMode={false}
+                setKeyboardEventHandlingMode={noop}
             />
         );
 
@@ -98,6 +99,7 @@ describe("Image cell", () => {
                 value={cell}
                 target={target}
                 forceEditMode={false}
+                setKeyboardEventHandlingMode={noop}
             />
         );
 


### PR DESCRIPTION
fix: reset the overlay state, when new row is created from trailing row and first cell is focused