### PR TITLE
fix: dummy space when vertical border is disabled

### DIFF
--- a/packages/core/src/data-grid/data-grid-render.tsx
+++ b/packages/core/src/data-grid/data-grid-render.tsx
@@ -854,7 +854,7 @@ function drawGridHeaders(
         const bgFillStyle = selected ? theme.accentColor : hasSelectedCell ? theme.bgHeaderHasFocus : theme.bgHeader;
 
         const y = enableGroups ? groupHeaderHeight : 0;
-        const xOffset = c.sourceIndex === 0 ? 0 : 1;
+        const xOffset = c.sourceIndex === 0 || !verticalBorder(c.sourceIndex) ? 0 : 1;
 
         if (selected) {
             ctx.fillStyle = bgFillStyle;
@@ -929,7 +929,8 @@ function clipDamage(
     getRowHeight: (row: number) => number,
     trailingRowType: TrailingRowType,
     damage: CellList | undefined,
-    includeCells: boolean
+    includeCells: boolean,
+    verticalBorder: (col: number) => boolean,
 ): void {
     if (damage === undefined || damage.length === 0) return;
 
@@ -956,8 +957,9 @@ function clipDamage(
         (c, drawX, colDrawY, clipX, startRow) => {
             const diff = Math.max(0, clipX - drawX);
 
-            const finalX = drawX + diff + 1;
-            const finalWidth = c.width - diff - 1;
+            const xOffset = verticalBorder(c.sourceIndex) ? 1 : 0
+            const finalX = drawX + diff + xOffset;
+            const finalWidth = c.width - diff - xOffset;
             for (let i = 0; i < damage.length; i++) {
                 const d = damage[i];
                 if (d[0] === c.sourceIndex && (d[1] === -1 || d[1] === undefined)) {
@@ -2184,7 +2186,8 @@ export function drawGrid(arg: DrawGridArg, lastArg: DrawGridArg | undefined) {
                 getRowHeight,
                 trailingRowType,
                 damage,
-                true
+                true,
+                verticalBorder
             );
 
             targetCtx.fillStyle = theme.bgCell;
@@ -2266,7 +2269,8 @@ export function drawGrid(arg: DrawGridArg, lastArg: DrawGridArg | undefined) {
                 getRowHeight,
                 trailingRowType,
                 damage,
-                false
+                false,
+                verticalBorder
             );
             drawHeaderTexture();
         }


### PR DESCRIPTION
When the vertical border is disabled (`verticalBorder={false}`) it was still adding 1px space for borders from each side of the column.