### PR TITLE
fix: replace mousedown with pointerdown in click outside container

### DIFF
--- a/packages/core/src/internal/click-outside-container/click-outside-container.tsx
+++ b/packages/core/src/internal/click-outside-container/click-outside-container.tsx
@@ -9,13 +9,13 @@ export default class ClickOutsideContainer extends React.PureComponent<Props> {
 
     public componentDidMount() {
         document.addEventListener("touchend", this.clickOutside, true);
-        document.addEventListener("mousedown", this.clickOutside, true);
+        document.addEventListener("pointerdown", this.clickOutside, true);
         document.addEventListener("contextmenu", this.clickOutside, true);
     }
 
     public componentWillUnmount() {
         document.removeEventListener("touchend", this.clickOutside, true);
-        document.removeEventListener("mousedown", this.clickOutside, true);
+        document.removeEventListener("pointerdown", this.clickOutside, true);
         document.removeEventListener("contextmenu", this.clickOutside, true);
     }
 

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -20,6 +20,7 @@ import {
     prep,
     sendClick,
     sendTouchClick,
+    sendPointerClick,
     getCellCenterPositionForDefaultGrid,
     Context,
     standardBeforeEach,
@@ -1559,7 +1560,7 @@ describe("data-editor", () => {
         const overlay = screen.getByDisplayValue("j");
         expect(document.body.contains(overlay)).toBe(true);
 
-        sendClick(canvas, {
+        sendPointerClick(canvas, {
             clientX: 300, // Col B
             clientY: 36 + 32 * 5 + 16, // Row 1 (0 indexed)
         });

--- a/packages/core/test/test-utils.tsx
+++ b/packages/core/test/test-utils.tsx
@@ -46,6 +46,14 @@ export function sendTouchClick(el: Element | Node | Document | Window, options?:
     });
 }
 
+export function sendPointerClick(el: Element | Node | Document | Window, options?: any): void {
+    fireEvent.pointerDown(el, options);
+
+    fireEvent.pointerUp(el, options);
+
+    fireEvent.click(el, options);
+}
+
 export const makeCell = (cell: Item): GridCell => {
     const [col, row] = cell;
     switch (col) {


### PR DESCRIPTION
Use `pointerdown` event instead of `mousedown` for outside click detection. Pointer events are hardware-agnostic and are designed to create a single DOM event model to handle pointing input devices such as a mouse, pen/stylus or touch (such as one or more fingers). Source: [Pointer events](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events)