### PR TITLE
feat: pass the hoverX and hoverY to the drawHeader args

### DIFF
--- a/packages/core/src/internal/data-grid/data-grid-types.ts
+++ b/packages/core/src/internal/data-grid/data-grid-types.ts
@@ -51,6 +51,8 @@ export type DrawHeaderCallback = (
         hasSelectedCell: boolean;
         spriteManager: SpriteManager;
         menuBounds: Rectangle;
+        hoverX: number | undefined;
+        hoverY: number | undefined;
     },
     drawContent: () => void
 ) => void;

--- a/packages/core/src/internal/data-grid/render/data-grid-render.header.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.header.ts
@@ -645,6 +645,8 @@ export function drawHeader(
                 hasSelectedCell,
                 spriteManager,
                 menuBounds: headerLayout?.menuBounds ?? { x: 0, y: 0, height: 0, width: 0 },
+                hoverX: posX,
+                hoverY: posY,
             },
             () =>
                 drawHeaderInner(


### PR DESCRIPTION
This PR adds the `hoverX` and the `hoverY` to the argument object of the `drawHeader` prop callback.