### PR TITLE
Remove extra horizontal scrollbar space, improve row height estimation

### DIFF
--- a/.github/workflows/release.js.yml
+++ b/.github/workflows/release.js.yml
@@ -28,39 +28,39 @@ jobs:
                   token: ${{ secrets.NPM_TOKEN }}
                   access: public
                   package: ./packages/core/package.json
-    publish-cells:
-        defaults:
-            run:
-                working-directory: ./packages/cells
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: 20.10.0
-            - name: Bootstrap
-              run: npm install && npm run build
-              working-directory: .
-            - uses: JS-DevTools/npm-publish@v1
-              with:
-                  token: ${{ secrets.NPM_TOKEN }}
-                  access: public
-                  package: ./packages/cells/package.json
-    publish-source:
-        defaults:
-            run:
-                working-directory: ./packages/source
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: 20.10.0
-            - name: Bootstrap
-              run: npm install && npm run build
-              working-directory: .
-            - uses: JS-DevTools/npm-publish@v1
-              with:
-                  token: ${{ secrets.NPM_TOKEN }}
-                  access: public
-                  package: ./packages/source/package.json
+    # publish-cells:
+    #     defaults:
+    #         run:
+    #             working-directory: ./packages/cells
+    #     runs-on: ubuntu-latest
+    #     steps:
+    #         - uses: actions/checkout@v4
+    #         - uses: actions/setup-node@v4
+    #           with:
+    #               node-version: 20.10.0
+    #         - name: Bootstrap
+    #           run: npm install && npm run build
+    #           working-directory: .
+    #         - uses: JS-DevTools/npm-publish@v1
+    #           with:
+    #               token: ${{ secrets.NPM_TOKEN }}
+    #               access: public
+    #               package: ./packages/cells/package.json
+    # publish-source:
+    #     defaults:
+    #         run:
+    #             working-directory: ./packages/source
+    #     runs-on: ubuntu-latest
+    #     steps:
+    #         - uses: actions/checkout@v4
+    #         - uses: actions/setup-node@v4
+    #           with:
+    #               node-version: 20.10.0
+    #         - name: Bootstrap
+    #           run: npm install && npm run build
+    #           working-directory: .
+    #         - uses: JS-DevTools/npm-publish@v1
+    #           with:
+    #               token: ${{ secrets.NPM_TOKEN }}
+    #               access: public
+    #               package: ./packages/source/package.json

--- a/.github/workflows/release.js.yml
+++ b/.github/workflows/release.js.yml
@@ -28,39 +28,39 @@ jobs:
                   token: ${{ secrets.NPM_TOKEN }}
                   access: public
                   package: ./packages/core/package.json
-    # publish-cells:
-    #     defaults:
-    #         run:
-    #             working-directory: ./packages/cells
-    #     runs-on: ubuntu-latest
-    #     steps:
-    #         - uses: actions/checkout@v4
-    #         - uses: actions/setup-node@v4
-    #           with:
-    #               node-version: 20.10.0
-    #         - name: Bootstrap
-    #           run: npm install && npm run build
-    #           working-directory: .
-    #         - uses: JS-DevTools/npm-publish@v1
-    #           with:
-    #               token: ${{ secrets.NPM_TOKEN }}
-    #               access: public
-    #               package: ./packages/cells/package.json
-    # publish-source:
-    #     defaults:
-    #         run:
-    #             working-directory: ./packages/source
-    #     runs-on: ubuntu-latest
-    #     steps:
-    #         - uses: actions/checkout@v4
-    #         - uses: actions/setup-node@v4
-    #           with:
-    #               node-version: 20.10.0
-    #         - name: Bootstrap
-    #           run: npm install && npm run build
-    #           working-directory: .
-    #         - uses: JS-DevTools/npm-publish@v1
-    #           with:
-    #               token: ${{ secrets.NPM_TOKEN }}
-    #               access: public
-    #               package: ./packages/source/package.json
+    publish-cells:
+        defaults:
+            run:
+                working-directory: ./packages/cells
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 20.10.0
+            - name: Bootstrap
+              run: npm install && npm run build
+              working-directory: .
+            - uses: JS-DevTools/npm-publish@v1
+              with:
+                  token: ${{ secrets.NPM_TOKEN }}
+                  access: public
+                  package: ./packages/cells/package.json
+    publish-source:
+        defaults:
+            run:
+                working-directory: ./packages/source
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 20.10.0
+            - name: Bootstrap
+              run: npm install && npm run build
+              working-directory: .
+            - uses: JS-DevTools/npm-publish@v1
+              with:
+                  token: ${{ secrets.NPM_TOKEN }}
+                  access: public
+                  package: ./packages/source/package.json

--- a/packages/core/API.md
+++ b/packages/core/API.md
@@ -13,14 +13,9 @@ or you can create a portal element yourself using the `createPortal` function fr
 ```jsx
 const portalRef = useRef(null);
 <>
-  {
-    createPortal(
-      <div ref={portalRef} style="position: fixed; left: 0; top: 0; z-index: 9999;" />,
-      document.body
-    )
-  }
-  <DataEditor width={500} height={300} portalElementRef={portalRef} {...props} />
-</>
+    {createPortal(<div ref={portalRef} style="position: fixed; left: 0; top: 0; z-index: 9999;" />, document.body)}
+    <DataEditor width={500} height={300} portalElementRef={portalRef} {...props} />
+</>;
 ```
 
 Once you've got that done, the easiest way to use the Data Grid is to give it a fixed size:
@@ -87,10 +82,10 @@ All data grids must set these props. These props are the bare minimum required t
 Most data grids will want to set the majority of these props one way or another.
 
 | Name                                              | Description                                                                                                                                                                                                                                                         |
-|---------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [fixedShadowX](#fixedshadow)                      | Enable/disable a shadow behind fixed columns on the X axis.                                                                                                                                                                                                         |
 | [fixedShadowY](#fixedshadow)                      | Enable/disable a shadow behind the header(s) on the Y axis.                                                                                                                                                                                                         |
-| [freezeColumns](#freezecolumns)                   | The number of columns which should remain in place when scrolling horizontally. The row marker column, if enabled is always frozen and is not included in this count.                                                                                               |
+| [freezeColumns](#freezecolumns)                   | The number of columns which should remain in place when scrolling horizontally, or a tuple `[left, right]` to freeze columns on both sides. The row marker column, if enabled is always frozen and is not included in this count.                                   |
 | [getCellsForSelection](#getcellsforselection)     | Used to fetch large amounts of cells at once. Used for copy/paste, if unset copy will not work.                                                                                                                                                                     |
 | [markdownDivCreateNode](#markdowndivcreatenode)   | If specified, it will be used to render Markdown, instead of the default Markdown renderer used by the Grid. You'll want to use this if you need to process your Markdown for security purposes, or if you want to use a renderer with different Markdown features. |
 | [onVisibleRegionChanged](#onvisibleregionchanged) | Emits whenever the visible rows/columns changes.                                                                                                                                                                                                                    |
@@ -192,7 +187,7 @@ Most data grids will want to set the majority of these props one way or another.
 | [onRowMoved](#onrowmoved)                             | Emitted when a row has been dragged to a new location.                                                                                                                              |
 | [preventDiagonalScrolling](#preventdiagonalscrolling) | Prevents diagonal scrolling                                                                                                                                                         |
 | [rowSelectionMode](#rowselectionmode)                 | Determines if row selection requires a modifier key to enable multi-selection or not.                                                                                               |
-| [columnSelectionMode](#columnselectionmode)           | Determines if column selection requires a modifier key to enable multi-selection or not.                                                                                             |
+| [columnSelectionMode](#columnselectionmode)           | Determines if column selection requires a modifier key to enable multi-selection or not.                                                                                            |
 | [scrollToEnd](#scrolltoend)                           | When set to true, the grid will scroll to the end. The ref has a better method to do this and this prop should not be used but it will remain supported for the foreseeable future. |
 | [showMinimap](#showminimap)                           | Shows the interactive minimap of the grid.                                                                                                                                          |
 | [validateCell](#validatecell)                         | When returns false indicates to the user the value will not be accepted. When returns a new GridCell the value is coerced to match.                                                 |
@@ -550,10 +545,17 @@ getCellContent: (cell: Item) => GridCell;
 ## freezeColumns
 
 ```ts
-freezeColumns?: number;
+freezeColumns?: number | readonly [left: number, right: number];
 ```
 
 Set to a positive number to freeze columns on the left side of the grid during horizontal scrolling.
+
+Alternatively, pass a tuple `[left, right]` where:
+
+- `left` is the number of columns to freeze on the left side
+- `right` is the number of columns to freeze on the right side
+
+Note: The row marker column, if enabled, is always frozen and is not included in the left freeze count.
 
 ---
 

--- a/packages/core/src/common/render-state-provider.ts
+++ b/packages/core/src/common/render-state-provider.ts
@@ -35,33 +35,42 @@ export abstract class WindowingTrackerBase {
         height: 0,
     };
 
-    public freezeCols: number = 0;
+    public columnsLength: number = 0;
+    public freezeCols: number | readonly [number, number] = 0;
     public freezeRows: number[] = [];
 
     protected isInWindow = (packed: number) => {
+        const freezeColumnsLeft = typeof this.freezeCols === "number" ? this.freezeCols : this.freezeCols[0];
+        const freezeColumnsRight = typeof this.freezeCols === "number" ? 0 : this.freezeCols[1];
         const col = unpackCol(packed);
         const row = unpackRow(packed);
         const w = this.visibleWindow;
-        const colInWindow = (col >= w.x && col <= w.x + w.width) || col < this.freezeCols;
+        const colInWindow =
+            (col >= w.x && col <= w.x + w.width) ||
+            col < freezeColumnsLeft ||
+            col > this.columnsLength - freezeColumnsRight - 1;
+
         const rowInWindow = (row >= w.y && row <= w.y + w.height) || this.freezeRows.includes(row);
         return colInWindow && rowInWindow;
     };
 
     protected abstract clearOutOfWindow: () => void;
 
-    public setWindow(newWindow: Rectangle, freezeCols: number, freezeRows: number[]): void {
+    public setWindow(newWindow: Rectangle, freezeCols: number, freezeRows: number[], columnsLength: number): void {
         if (
             this.visibleWindow.x === newWindow.x &&
             this.visibleWindow.y === newWindow.y &&
             this.visibleWindow.width === newWindow.width &&
             this.visibleWindow.height === newWindow.height &&
             this.freezeCols === freezeCols &&
+            this.columnsLength === columnsLength &&
             deepEqual(this.freezeRows, freezeRows)
         )
             return;
         this.visibleWindow = newWindow;
         this.freezeCols = freezeCols;
         this.freezeRows = freezeRows;
+        this.columnsLength = columnsLength;
         this.clearOutOfWindow();
     }
 }

--- a/packages/core/src/common/utils.tsx
+++ b/packages/core/src/common/utils.tsx
@@ -282,3 +282,10 @@ export function useDeepMemo<T>(value: T): T {
 
     return ref.current;
 }
+
+export function normalizeFreezeColumns(freezeColumns: number | readonly [number, number]): readonly [number, number] {
+    const freezeLeftColumns = typeof freezeColumns === "number" ? freezeColumns : freezeColumns[0];
+    const freezeRightColumns = typeof freezeColumns === "number" ? 0 : freezeColumns[1];
+
+    return [freezeLeftColumns, freezeRightColumns];
+}

--- a/packages/core/src/data-editor/data-editor-keybindings.ts
+++ b/packages/core/src/data-editor/data-editor-keybindings.ts
@@ -67,6 +67,8 @@ export interface ConfigurableKeybinds {
     readonly selectAll: Keybind;
     readonly selectRow: Keybind;
     readonly selectColumn: Keybind;
+
+    readonly contextMenu: Keybind;
 }
 
 export type Keybinds = ConfigurableKeybinds & ForcedKeybinds & Partial<BackCompatKeybinds>;
@@ -118,6 +120,7 @@ export const keybindingDefaults: Keybinds = {
     selectGrowRight: true,
     selectGrowDown: true,
     selectGrowLeft: true,
+    contextMenu: true,
 };
 
 function realizeKeybind(keybind: Keybind, defaultVal: string): string {
@@ -174,6 +177,7 @@ export function realizeKeybinds(keybinds: Keybinds): RealizedKeybinds {
         selectToLastCell: realizeKeybind(keybinds.selectToLastCell, "primary+shift+End"),
         selectToLastColumn: realizeKeybind(keybinds.selectToLastColumn, "primary+shift+ArrowRight"),
         selectToLastRow: realizeKeybind(keybinds.selectToLastRow, "primary+shift+ArrowDown"),
+        contextMenu: realizeKeybind(keybinds.contextMenu, "shift+F10"),
     };
 }
 

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -923,7 +923,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
     const maxColumnWidth = Math.max(maxColumnWidthIn, minColumnWidth);
     const maxColumnAutoWidth = Math.max(maxColumnAutoWidthIn ?? maxColumnWidth, minColumnWidth);
 
-    const freezeLeftColumns = typeof freezeColumns === "number" ? freezeColumns: freezeColumns[0];
+    const freezeLeftColumns = typeof freezeColumns === "number" ? freezeColumns : freezeColumns[0];
     const freezeRightColumns = typeof freezeColumns === "number" ? 0 : freezeColumns[1];
 
     const docStyle = React.useMemo(() => {
@@ -1595,7 +1595,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                         }
 
                         // scrollBounds is already scaled
-                        let sLeft = frozenLeftWidth * scale + scrollBounds.left + rowMarkerOffset * rowMarkerWidth * scale;
+                        let sLeft =
+                            frozenLeftWidth * scale + scrollBounds.left + rowMarkerOffset * rowMarkerWidth * scale;
                         let sRight = scrollBounds.right - frozenRightWidth * scale;
                         let sTop = scrollBounds.top + totalHeaderHeight * scale;
                         let sBottom = scrollBounds.bottom - trailingRowHeight * scale;

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -1581,7 +1581,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                             frozenLeftWidth += columns[i].width;
                         }
                         let frozenRightWidth = 0;
-                        for (let i = mangledCols.length - 1; i >= mangledCols.length - freezeRightColumns; i--) {
+                        for (let i = columns.length - 1; i >= columns.length - 1 - freezeRightColumns; i--) {
                             frozenRightWidth += columns[i].width;
                         }
                         let trailingRowHeight = 0;

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -923,6 +923,9 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
     const maxColumnWidth = Math.max(maxColumnWidthIn, minColumnWidth);
     const maxColumnAutoWidth = Math.max(maxColumnAutoWidthIn ?? maxColumnWidth, minColumnWidth);
 
+    const freezeLeftColumns = typeof freezeColumns === "number" ? freezeColumns: freezeColumns[0];
+    const freezeRightColumns = typeof freezeColumns === "number" ? 0 : freezeColumns[1];
+
     const docStyle = React.useMemo(() => {
         if (typeof window === "undefined") return { fontSize: "16px" };
         return window.getComputedStyle(document.documentElement);
@@ -1573,9 +1576,13 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                             height: targetRect.height + 2 * paddingY,
                         };
 
-                        let frozenWidth = 0;
-                        for (let i = 0; i < freezeColumns; i++) {
-                            frozenWidth += columns[i].width;
+                        let frozenLeftWidth = 0;
+                        for (let i = 0; i < freezeLeftColumns; i++) {
+                            frozenLeftWidth += columns[i].width;
+                        }
+                        let frozenRightWidth = 0;
+                        for (let i = mangledCols.length - 1; i >= mangledCols.length - freezeRightColumns; i--) {
+                            frozenRightWidth += columns[i].width;
                         }
                         let trailingRowHeight = 0;
                         const freezeTrailingRowsEffective = freezeTrailingRows + (lastRowSticky ? 1 : 0);
@@ -1588,8 +1595,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                         }
 
                         // scrollBounds is already scaled
-                        let sLeft = frozenWidth * scale + scrollBounds.left + rowMarkerOffset * rowMarkerWidth * scale;
-                        let sRight = scrollBounds.right;
+                        let sLeft = frozenLeftWidth * scale + scrollBounds.left + rowMarkerOffset * rowMarkerWidth * scale;
+                        let sRight = scrollBounds.right - frozenRightWidth * scale;
                         let sTop = scrollBounds.top + totalHeaderHeight * scale;
                         let sBottom = scrollBounds.bottom - trailingRowHeight * scale;
 
@@ -1633,7 +1640,11 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                             scrollY = bounds.y + bounds.height - sBottom;
                         }
 
-                        if (dir === "vertical" || (typeof col === "number" && col < freezeColumns)) {
+                        if (
+                            dir === "vertical" ||
+                            (typeof col === "number" &&
+                                (col < freezeLeftColumns || col >= mangledCols.length - freezeRightColumns))
+                        ) {
                             scrollX = 0;
                         } else if (
                             dir === "horizontal" ||
@@ -1664,7 +1675,9 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             rowMarkerWidth,
             scrollRef,
             totalHeaderHeight,
-            freezeColumns,
+            freezeLeftColumns,
+            freezeRightColumns,
+            mangledCols.length,
             columns,
             mangledRows,
             lastRowSticky,
@@ -2596,18 +2609,29 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 selected = [selected[0] - rowMarkerOffset, selected[1]];
             }
 
-            const freezeRegion =
-                freezeColumns === 0
+            const freezeLeftRegion =
+                freezeLeftColumns === 0
                     ? undefined
                     : {
                           x: 0,
                           y: region.y,
-                          width: freezeColumns,
+                          width: freezeLeftColumns,
+                          height: region.height,
+                      };
+
+            const freezeRightRegion =
+                freezeRightColumns === 0
+                    ? undefined
+                    : {
+                          x: columns.length - freezeRightColumns,
+                          y: region.y,
+                          width: freezeRightColumns,
                           height: region.height,
                       };
 
             const freezeRegions: Rectangle[] = [];
-            if (freezeRegion !== undefined) freezeRegions.push(freezeRegion);
+            if (freezeLeftRegion !== undefined) freezeRegions.push(freezeLeftRegion);
+            if (freezeRightRegion !== undefined) freezeRegions.push(freezeRightRegion);
             if (freezeTrailingRows > 0) {
                 freezeRegions.push({
                     x: region.x - rowMarkerOffset,
@@ -2616,11 +2640,20 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     height: freezeTrailingRows,
                 });
 
-                if (freezeColumns > 0) {
+                if (freezeLeftColumns > 0) {
                     freezeRegions.push({
                         x: 0,
                         y: rows - freezeTrailingRows,
-                        width: freezeColumns,
+                        width: freezeLeftColumns,
+                        height: freezeTrailingRows,
+                    });
+                }
+
+                if (freezeRightColumns > 0) {
+                    freezeRegions.push({
+                        x: columns.length - freezeRightColumns,
+                        y: rows - freezeTrailingRows,
+                        width: freezeRightColumns,
                         height: freezeTrailingRows,
                     });
                 }
@@ -2635,7 +2668,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 ty,
                 extras: {
                     selected,
-                    freezeRegion,
+                    freezeRegion: freezeLeftRegion,
                     freezeRegions,
                 },
             };
@@ -2649,7 +2682,9 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             rowMarkerOffset,
             showTrailingBlankRow,
             rows,
-            freezeColumns,
+            freezeLeftColumns,
+            freezeRightColumns,
+            columns.length,
             freezeTrailingRows,
             setVisibleRegion,
             onVisibleRegionChanged,
@@ -3991,7 +4026,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         );
     }, [onGroupHeaderRenamed, renameGroup]);
 
-    const mangledFreezeColumns = Math.min(mangledCols.length, freezeColumns + (hasRowMarkers ? 1 : 0));
+    const mangledFreezeColumns = Math.min(mangledCols.length, freezeLeftColumns + (hasRowMarkers ? 1 : 0));
 
     React.useImperativeHandle(
         forwardedRef,
@@ -4259,7 +4294,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     onColumnProposeMove={onColumnProposeMoveImpl}
                     drawCell={drawCell}
                     disabledRows={disabledRows}
-                    freezeColumns={mangledFreezeColumns}
+                    freezeColumns={[mangledFreezeColumns, freezeRightColumns]}
                     lockColumns={rowMarkerOffset}
                     firstColAccessible={rowMarkerOffset === 0}
                     getCellContent={getMangledCellContent}

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -4026,7 +4026,12 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         );
     }, [onGroupHeaderRenamed, renameGroup]);
 
-    const mangledFreezeColumns = Math.min(mangledCols.length, freezeLeftColumns + (hasRowMarkers ? 1 : 0));
+    const mangledFreezeColumns = React.useMemo(() => {
+      return [
+        Math.min(mangledCols.length, freezeLeftColumns + (hasRowMarkers ? 1 : 0)),
+        Math.min(mangledCols.length, freezeRightColumns)
+      ] as const;
+    }, [freezeLeftColumns, freezeRightColumns, hasRowMarkers, mangledCols.length])
 
     React.useImperativeHandle(
         forwardedRef,
@@ -4294,7 +4299,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     onColumnProposeMove={onColumnProposeMoveImpl}
                     drawCell={drawCell}
                     disabledRows={disabledRows}
-                    freezeColumns={[mangledFreezeColumns, freezeRightColumns]}
+                    freezeColumns={mangledFreezeColumns}
                     lockColumns={rowMarkerOffset}
                     firstColAccessible={rowMarkerOffset === 0}
                     getCellContent={getMangledCellContent}

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -44,7 +44,7 @@ import {
     mergeAndRealizeTheme,
 } from "../common/styles.js";
 import type { DataGridRef } from "../internal/data-grid/data-grid.js";
-import { getScrollBarWidth, useEventListener, whenDefined } from "../common/utils.js";
+import { getScrollBarWidth, useEventListener, normalizeFreezeColumns, whenDefined } from "../common/utils.js";
 import {
     isGroupEqual,
     itemsAreEqual,
@@ -923,8 +923,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
     const maxColumnWidth = Math.max(maxColumnWidthIn, minColumnWidth);
     const maxColumnAutoWidth = Math.max(maxColumnAutoWidthIn ?? maxColumnWidth, minColumnWidth);
 
-    const freezeLeftColumns = typeof freezeColumns === "number" ? freezeColumns : freezeColumns[0];
-    const freezeRightColumns = typeof freezeColumns === "number" ? 0 : freezeColumns[1];
+    const [freezeLeftColumns, freezeRightColumns] = normalizeFreezeColumns(freezeColumns);
 
     const docStyle = React.useMemo(() => {
         if (typeof window === "undefined") return { fontSize: "16px" };
@@ -1581,7 +1580,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                             frozenLeftWidth += columns[i].width;
                         }
                         let frozenRightWidth = 0;
-                        for (let i = columns.length - 1; i >= columns.length - 1 - freezeRightColumns; i--) {
+                        for (let i = columns.length - 1; i >= columns.length - freezeRightColumns; i--) {
                             frozenRightWidth += columns[i].width;
                         }
                         let trailingRowHeight = 0;

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3263,7 +3263,6 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     }
                 }
             }
-            console.log({event, details}, "keys.contextMenu:", keys.contextMenu, overlayOpen )
 
             if (details.didMatch) {
                 cancel();
@@ -3363,6 +3362,34 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     col = Number.MAX_SAFE_INTEGER;
                 } else if (isHotkey(keys.goToFirstColumn, event, details)) {
                     col = Number.MIN_SAFE_INTEGER;
+                } else if (isHotkey(keys.contextMenu, event, details) &&
+                  bounds !== undefined &&
+                  event.location !== undefined
+                ) {
+                  const {
+                    location,
+                    ctrlKey,
+                    metaKey,
+                    shiftKey,
+                  } = event;
+
+                  onContextMenu(
+                    {
+                      kind: "cell",
+                      isFillHandle: false,
+                      isTouch: false,
+                      isEdge: false,
+                      button: 0,
+                      scrollEdge: [0, 0],
+                      localEventX: bounds.width / 2,
+                      localEventY: bounds.height / 2,
+                      location,
+                      bounds,
+                      ctrlKey,
+                      metaKey,
+                      shiftKey,
+                      buttons: 0
+                    }, cancel)
                 } else if (rangeSelect === "rect" || rangeSelect === "multi-rect") {
                   if (isHotkey(keys.selectGrowDown, event, details)) {
                     adjustSelection([0, 1]);
@@ -3380,27 +3407,6 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     adjustSelection([2, 0]);
                   } else if (isHotkey(keys.selectToFirstColumn, event, details)) {
                     adjustSelection([-2, 0]);
-                  } else if (isHotkey(keys.contextMenu, event, details) &&
-                    event.bounds !== undefined &&
-                    event.location !== undefined
-                  ) {
-                    onContextMenu(
-                      {
-                        kind: "cell",
-                        isFillHandle: false,
-                        isTouch: false,
-                        isEdge: false,
-                        button: 0,
-                        scrollEdge: [0, 0],
-                        localEventX: event.bounds.width / 2,
-                        localEventY: event.bounds.height / 2,
-                        location: [col, row],
-                        bounds: event.bounds,
-                        ctrlKey: false,
-                        metaKey: false,
-                        shiftKey: true,
-                        buttons: 0
-                      }, cancel)
                   }
                 }
                 cancelOnlyOnMove = details.didMatch;

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3185,6 +3185,42 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
 
     const overlayOpen = overlay !== undefined;
 
+    const onContextMenu = React.useCallback(
+      (args: GridMouseEventArgs, preventDefault: () => void) => {
+        const adjustedCol = args.location[0] - rowMarkerOffset;
+        if (args.kind === "header") {
+          onHeaderContextMenu?.(adjustedCol, { ...args, preventDefault });
+        }
+
+        if (args.kind === groupHeaderKind) {
+          if (adjustedCol < 0) {
+            return;
+          }
+          onGroupHeaderContextMenu?.(adjustedCol, { ...args, preventDefault });
+        }
+
+        if (args.kind === "cell") {
+          const [col, row] = args.location;
+          onCellContextMenu?.([adjustedCol, row], {
+            ...args,
+            preventDefault,
+          });
+
+          if (!gridSelectionHasItem(gridSelection, args.location)) {
+            updateSelectedCell(col, row, false, false);
+          }
+        }
+      },
+      [
+        gridSelection,
+        onCellContextMenu,
+        onGroupHeaderContextMenu,
+        onHeaderContextMenu,
+        rowMarkerOffset,
+        updateSelectedCell,
+      ]
+    );
+
     const handleFixedKeybindings = React.useCallback(
         (event: GridKeyEventArgs): boolean => {
             const cancel = () => {
@@ -3480,6 +3516,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             return didMatch;
         },
         [
+            onContextMenu,
             rowGroupingNavBehavior,
             overlayOpen,
             gridSelection,
@@ -3570,42 +3607,6 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             showTrailingBlankRow,
             onCellActivated,
             reselect,
-        ]
-    );
-
-    const onContextMenu = React.useCallback(
-        (args: GridMouseEventArgs, preventDefault: () => void) => {
-            const adjustedCol = args.location[0] - rowMarkerOffset;
-            if (args.kind === "header") {
-                onHeaderContextMenu?.(adjustedCol, { ...args, preventDefault });
-            }
-
-            if (args.kind === groupHeaderKind) {
-                if (adjustedCol < 0) {
-                    return;
-                }
-                onGroupHeaderContextMenu?.(adjustedCol, { ...args, preventDefault });
-            }
-
-            if (args.kind === "cell") {
-                const [col, row] = args.location;
-                onCellContextMenu?.([adjustedCol, row], {
-                    ...args,
-                    preventDefault,
-                });
-
-                if (!gridSelectionHasItem(gridSelection, args.location)) {
-                    updateSelectedCell(col, row, false, false);
-                }
-            }
-        },
-        [
-            gridSelection,
-            onCellContextMenu,
-            onGroupHeaderContextMenu,
-            onHeaderContextMenu,
-            rowMarkerOffset,
-            updateSelectedCell,
         ]
     );
 

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3362,52 +3362,53 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     col = Number.MAX_SAFE_INTEGER;
                 } else if (isHotkey(keys.goToFirstColumn, event, details)) {
                     col = Number.MIN_SAFE_INTEGER;
-                } else if (isHotkey(keys.contextMenu, event, details) &&
-                  bounds !== undefined &&
-                  event.location !== undefined
+                } else if (
+                    isHotkey(keys.contextMenu, event, details) &&
+                    bounds !== undefined &&
+                    event.location !== undefined
                 ) {
-                  const {
-                    location,
-                    ctrlKey,
-                    metaKey,
-                    shiftKey,
-                  } = event;
-
-                  onContextMenu(
-                    {
-                      kind: "cell",
-                      isFillHandle: false,
-                      isTouch: false,
-                      isEdge: false,
-                      button: 0,
-                      scrollEdge: [0, 0],
-                      localEventX: bounds.width / 2,
-                      localEventY: bounds.height / 2,
+                    const {
                       location,
-                      bounds,
                       ctrlKey,
                       metaKey,
                       shiftKey,
-                      buttons: 0
-                    }, cancel)
+                    } = event;
+
+                    onContextMenu(
+                      {
+                        kind: "cell",
+                        isFillHandle: false,
+                        isTouch: false,
+                        isEdge: false,
+                        button: 0,
+                        scrollEdge: [0, 0],
+                        localEventX: bounds.width / 2,
+                        localEventY: bounds.height / 2,
+                        location,
+                        bounds,
+                        ctrlKey,
+                        metaKey,
+                        shiftKey,
+                        buttons: 0
+                      }, cancel)
                 } else if (rangeSelect === "rect" || rangeSelect === "multi-rect") {
-                  if (isHotkey(keys.selectGrowDown, event, details)) {
-                    adjustSelection([0, 1]);
-                  } else if (isHotkey(keys.selectGrowUp, event, details)) {
-                    adjustSelection([0, -1]);
-                  } else if (isHotkey(keys.selectGrowRight, event, details)) {
-                    adjustSelection([1, 0]);
-                  } else if (isHotkey(keys.selectGrowLeft, event, details)) {
-                    adjustSelection([-1, 0]);
-                  } else if (isHotkey(keys.selectToLastRow, event, details)) {
-                    adjustSelection([0, 2]);
-                  } else if (isHotkey(keys.selectToFirstRow, event, details)) {
-                    adjustSelection([0, -2]);
-                  } else if (isHotkey(keys.selectToLastColumn, event, details)) {
-                    adjustSelection([2, 0]);
-                  } else if (isHotkey(keys.selectToFirstColumn, event, details)) {
-                    adjustSelection([-2, 0]);
-                  }
+                    if (isHotkey(keys.selectGrowDown, event, details)) {
+                        adjustSelection([0, 1]);
+                    } else if (isHotkey(keys.selectGrowUp, event, details)) {
+                        adjustSelection([0, -1]);
+                    } else if (isHotkey(keys.selectGrowRight, event, details)) {
+                        adjustSelection([1, 0]);
+                    } else if (isHotkey(keys.selectGrowLeft, event, details)) {
+                        adjustSelection([-1, 0]);
+                    } else if (isHotkey(keys.selectToLastRow, event, details)) {
+                        adjustSelection([0, 2]);
+                    } else if (isHotkey(keys.selectToFirstRow, event, details)) {
+                        adjustSelection([0, -2]);
+                    } else if (isHotkey(keys.selectToLastColumn, event, details)) {
+                        adjustSelection([2, 0]);
+                    } else if (isHotkey(keys.selectToFirstColumn, event, details)) {
+                        adjustSelection([-2, 0]);
+                    }
                 }
                 cancelOnlyOnMove = details.didMatch;
             } else {

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3263,6 +3263,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     }
                 }
             }
+            console.log({event, details}, "keys.contextMenu:", keys.contextMenu, overlayOpen )
 
             if (details.didMatch) {
                 cancel();
@@ -3363,23 +3364,44 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 } else if (isHotkey(keys.goToFirstColumn, event, details)) {
                     col = Number.MIN_SAFE_INTEGER;
                 } else if (rangeSelect === "rect" || rangeSelect === "multi-rect") {
-                    if (isHotkey(keys.selectGrowDown, event, details)) {
-                        adjustSelection([0, 1]);
-                    } else if (isHotkey(keys.selectGrowUp, event, details)) {
-                        adjustSelection([0, -1]);
-                    } else if (isHotkey(keys.selectGrowRight, event, details)) {
-                        adjustSelection([1, 0]);
-                    } else if (isHotkey(keys.selectGrowLeft, event, details)) {
-                        adjustSelection([-1, 0]);
-                    } else if (isHotkey(keys.selectToLastRow, event, details)) {
-                        adjustSelection([0, 2]);
-                    } else if (isHotkey(keys.selectToFirstRow, event, details)) {
-                        adjustSelection([0, -2]);
-                    } else if (isHotkey(keys.selectToLastColumn, event, details)) {
-                        adjustSelection([2, 0]);
-                    } else if (isHotkey(keys.selectToFirstColumn, event, details)) {
-                        adjustSelection([-2, 0]);
-                    }
+                  if (isHotkey(keys.selectGrowDown, event, details)) {
+                    adjustSelection([0, 1]);
+                  } else if (isHotkey(keys.selectGrowUp, event, details)) {
+                    adjustSelection([0, -1]);
+                  } else if (isHotkey(keys.selectGrowRight, event, details)) {
+                    adjustSelection([1, 0]);
+                  } else if (isHotkey(keys.selectGrowLeft, event, details)) {
+                    adjustSelection([-1, 0]);
+                  } else if (isHotkey(keys.selectToLastRow, event, details)) {
+                    adjustSelection([0, 2]);
+                  } else if (isHotkey(keys.selectToFirstRow, event, details)) {
+                    adjustSelection([0, -2]);
+                  } else if (isHotkey(keys.selectToLastColumn, event, details)) {
+                    adjustSelection([2, 0]);
+                  } else if (isHotkey(keys.selectToFirstColumn, event, details)) {
+                    adjustSelection([-2, 0]);
+                  } else if (isHotkey(keys.contextMenu, event, details) &&
+                    event.bounds !== undefined &&
+                    event.location !== undefined
+                  ) {
+                    onContextMenu(
+                      {
+                        kind: "cell",
+                        isFillHandle: false,
+                        isTouch: false,
+                        isEdge: false,
+                        button: 0,
+                        scrollEdge: [0, 0],
+                        localEventX: event.bounds.width / 2,
+                        localEventY: event.bounds.height / 2,
+                        location: [col, row],
+                        bounds: event.bounds,
+                        ctrlKey: false,
+                        metaKey: false,
+                        shiftKey: true,
+                        buttons: 0
+                      }, cancel)
+                  }
                 }
                 cancelOnlyOnMove = details.didMatch;
             } else {

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3619,7 +3619,20 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     (!showTrailingBlankRow || row !== rows) &&
                     (vr.y > row || row > vr.y + vr.height || vr.x > col || col > vr.x + vr.width)
                 ) {
-                    return;
+                    // Frozen columns/rows are always rendered regardless of scroll position, so
+                    // being outside the tracked scrollable region doesn't mean they're off-screen.
+                    let isInFreezeArea = false;
+                    if (vr.extras?.freezeRegions !== undefined) {
+                        for (const fr of vr.extras.freezeRegions) {
+                            if (pointInRect(fr, col, row)) {
+                                isInFreezeArea = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (!isInFreezeArea) {
+                        return;
+                    }
                 }
                 const activationEvent: CellActivatedEventArgs = {
                     inputType: "keyboard",

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -2736,6 +2736,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
 
     const onDragEnd = React.useCallback(() => {
         isActivelyDragging.current = false;
+        isActivelyDraggingHeader.current = false;
+        setScrollDir(undefined);
     }, []);
 
     const rowGroupingSelectionBehavior = rowGrouping?.selectionBehavior;

--- a/packages/core/src/docs/examples/freeze-columns.stories.tsx
+++ b/packages/core/src/docs/examples/freeze-columns.stories.tsx
@@ -30,14 +30,14 @@ export default {
     ],
 };
 
-export const FreezeColumns: React.VFC<any> = (p: { freezeColumns: number }) => {
+export const FreezeColumns: React.VFC<any> = (p: { freezeLeftColumns: number, freezeRightColumns: number }) => {
     const { cols, getCellContent } = useMockDataGenerator(100);
 
     return (
         <DataEditor
             {...defaultProps}
             rowMarkers="both"
-            freezeColumns={p.freezeColumns}
+            freezeColumns={[p.freezeLeftColumns, p.freezeRightColumns]}
             getCellContent={getCellContent}
             columns={cols}
             verticalBorder={false}
@@ -46,7 +46,14 @@ export const FreezeColumns: React.VFC<any> = (p: { freezeColumns: number }) => {
     );
 };
 (FreezeColumns as any).argTypes = {
-    freezeColumns: {
+    freezeLeftColumns: {
+        control: {
+            type: "range",
+            min: 0,
+            max: 10,
+        },
+    },
+    freezeRightColumns: {
         control: {
             type: "range",
             min: 0,
@@ -55,5 +62,6 @@ export const FreezeColumns: React.VFC<any> = (p: { freezeColumns: number }) => {
     },
 };
 (FreezeColumns as any).args = {
-    freezeColumns: 1,
+    freezeLeftColumns: 1,
+    freezeRightColumns: 1,
 };

--- a/packages/core/src/internal/data-grid/data-grid.tsx
+++ b/packages/core/src/internal/data-grid/data-grid.tsx
@@ -480,7 +480,7 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
                 translateX,
                 translateY,
                 rows,
-                freezeLeftColumns,
+                freezeColumns,
                 freezeTrailingRows,
                 mappedColumns,
                 rowHeight
@@ -508,7 +508,7 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
             translateX,
             translateY,
             rows,
-            freezeLeftColumns,
+            freezeColumns,
             freezeTrailingRows,
             mappedColumns,
             rowHeight,
@@ -1905,12 +1905,27 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
               ? 1
               : clamp(-translateX / 100, 0, 1);
 
+    let translateXRight = 0;
+
+    if (eventTargetRef?.current) {
+        translateXRight = eventTargetRef?.current?.scrollLeft + width - eventTargetRef?.current?.scrollWidth;
+    }
+
     const opacityXRight =
         freezeRightColumns === 0 || !fixedShadowX
             ? 0
-            : cellXOffset + width < columns.length - freezeRightColumns
+            : cellXOffset +
+                    getEffectiveColumns(
+                        mappedColumns,
+                        cellXOffset,
+                        width,
+                        freezeColumns,
+                        dragAndDropState,
+                        translateX
+                    ).filter(column => !column.sticky).length <
+                columns.length - freezeRightColumns
               ? 1
-              : clamp((translateX - (columns.length - freezeRightColumns - width) * 32) / 100, 0, 1);
+              : clamp(-translateXRight / 100, 0, 1);
 
     const absoluteOffsetY = -cellYOffset * 32 + translateY;
     const opacityY = !fixedShadowY ? 0 : clamp(-absoluteOffsetY / 100, 0, 1);

--- a/packages/core/src/internal/data-grid/data-grid.tsx
+++ b/packages/core/src/internal/data-grid/data-grid.tsx
@@ -625,7 +625,11 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
                 let isEdge = bounds !== undefined && bounds.x + bounds.width - posX <= edgeDetectionBuffer;
 
                 const previousCol = col - 1;
-                if (posX - bounds.x <= edgeDetectionBuffer && previousCol >= 0) {
+                if (
+                    posX - bounds.x <= edgeDetectionBuffer &&
+                    previousCol >= 0 &&
+                    col < mappedColumns.length - freezeRightColumns
+                ) {
                     isEdge = true;
                     bounds = getBoundsForItem(canvas, previousCol, row);
                     assert(bounds !== undefined);
@@ -733,6 +737,7 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
             selection,
             totalHeaderHeight,
             freezeColumns,
+            freezeRightColumns,
         ]
     );
 

--- a/packages/core/src/internal/data-grid/data-grid.tsx
+++ b/packages/core/src/internal/data-grid/data-grid.tsx
@@ -28,7 +28,13 @@ import {
 } from "./data-grid-types.js";
 import { CellSet } from "./cell-set.js";
 import { SpriteManager, type SpriteMap } from "./data-grid-sprites.js";
-import { direction, getScrollBarWidth, useDebouncedMemo, useEventListener } from "../../common/utils.js";
+import {
+    direction,
+    getScrollBarWidth,
+    useDebouncedMemo,
+    useEventListener,
+    normalizeFreezeColumns,
+} from "../../common/utils.js";
 import clamp from "lodash/clamp.js";
 import makeRange from "lodash/range.js";
 import { drawGrid } from "./render/data-grid-render.js";
@@ -403,8 +409,7 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
     } = p;
     const translateX = p.translateX ?? 0;
     const translateY = p.translateY ?? 0;
-    const freezeLeftColumns = typeof freezeColumns === "number" ? freezeColumns : freezeColumns[0];
-    const freezeRightColumns = typeof freezeColumns === "number" ? 0 : freezeColumns[1];
+    const [freezeLeftColumns, freezeRightColumns] = normalizeFreezeColumns(freezeColumns);
     const cellXOffset = Math.max(freezeLeftColumns, Math.min(columns.length - 1, cellXOffsetReal));
 
     const ref = React.useRef<HTMLCanvasElement | null>(null);

--- a/packages/core/src/internal/data-grid/data-grid.tsx
+++ b/packages/core/src/internal/data-grid/data-grid.tsx
@@ -1263,6 +1263,25 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
     );
     useEventListener("contextmenu", onContextMenuImpl, eventTargetRef?.current ?? null, false);
 
+    const onContextMenuWithKeyboardImpl = React.useCallback(
+      (ev: MouseEvent) => {
+        const canvas = ref.current;
+        const currentSelectedCell = selectionRef.current.current?.cell
+        if (canvas === null || onContextMenu === undefined || currentSelectedCell === undefined)
+          return;
+        const bounds = getBoundsForItem(canvas, ...currentSelectedCell);
+        if (bounds) {
+          const args = getMouseArgsForPosition(canvas, bounds.x + bounds.width / 2, bounds.y + bounds.height / 2, ev);
+          onContextMenu(args, () => {
+          if (ev.cancelable) ev.preventDefault();
+          });
+        }
+      },
+      [getMouseArgsForPosition, onContextMenu, getBoundsForItem]
+   );
+
+    useEventListener("contextmenu", onContextMenuWithKeyboardImpl, ref?.current ?? null, false);
+
     const onAnimationFrame = React.useCallback<StepCallback>(values => {
         damageRegion.current = new CellSet(values.map(x => x.item));
         hoverValues.current = values;

--- a/packages/core/src/internal/data-grid/data-grid.tsx
+++ b/packages/core/src/internal/data-grid/data-grid.tsx
@@ -72,7 +72,7 @@ export interface DataGridProps {
 
     readonly accessibilityHeight: number;
 
-    readonly freezeColumns: number | [left: number, right: number];
+    readonly freezeColumns: number | readonly [left: number, right: number];
     readonly freezeTrailingRows: number;
     readonly hasAppendRow: boolean;
     readonly firstColAccessible: boolean;

--- a/packages/core/src/internal/data-grid/data-grid.tsx
+++ b/packages/core/src/internal/data-grid/data-grid.tsx
@@ -1263,25 +1263,6 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
     );
     useEventListener("contextmenu", onContextMenuImpl, eventTargetRef?.current ?? null, false);
 
-    const onContextMenuWithKeyboardImpl = React.useCallback(
-      (ev: MouseEvent) => {
-        const canvas = ref.current;
-        const currentSelectedCell = selectionRef.current.current?.cell
-        if (canvas === null || onContextMenu === undefined || currentSelectedCell === undefined)
-          return;
-        const bounds = getBoundsForItem(canvas, ...currentSelectedCell);
-        if (bounds) {
-          const args = getMouseArgsForPosition(canvas, bounds.x + bounds.width / 2, bounds.y + bounds.height / 2, ev);
-          onContextMenu(args, () => {
-          if (ev.cancelable) ev.preventDefault();
-          });
-        }
-      },
-      [getMouseArgsForPosition, onContextMenu, getBoundsForItem]
-   );
-
-    useEventListener("contextmenu", onContextMenuWithKeyboardImpl, ref?.current ?? null, false);
-
     const onAnimationFrame = React.useCallback<StepCallback>(values => {
         damageRegion.current = new CellSet(values.map(x => x.item));
         hoverValues.current = values;

--- a/packages/core/src/internal/data-grid/image-window-loader-interface.ts
+++ b/packages/core/src/internal/data-grid/image-window-loader-interface.ts
@@ -6,7 +6,8 @@ export interface ImageWindowLoader {
     setWindow(
         newWindow: Rectangle,
         freezeCols: number | readonly [left: number, right: number],
-        freezeRows: number[]
+        freezeRows: number[],
+        columnsLength: number
     ): void;
     loadOrGetImage(url: string, col: number, row: number): HTMLImageElement | ImageBitmap | undefined;
     setCallback(imageLoaded: (locations: CellSet) => void): void;

--- a/packages/core/src/internal/data-grid/image-window-loader-interface.ts
+++ b/packages/core/src/internal/data-grid/image-window-loader-interface.ts
@@ -3,7 +3,7 @@ import type { Rectangle } from "./data-grid-types.js";
 
 /** @category Types */
 export interface ImageWindowLoader {
-    setWindow(newWindow: Rectangle, freezeCols: number, freezeRows: number[]): void;
+    setWindow(newWindow: Rectangle, freezeCols: number | [left: number, right: number], freezeRows: number[]): void;
     loadOrGetImage(url: string, col: number, row: number): HTMLImageElement | ImageBitmap | undefined;
     setCallback(imageLoaded: (locations: CellSet) => void): void;
 }

--- a/packages/core/src/internal/data-grid/image-window-loader-interface.ts
+++ b/packages/core/src/internal/data-grid/image-window-loader-interface.ts
@@ -3,7 +3,11 @@ import type { Rectangle } from "./data-grid-types.js";
 
 /** @category Types */
 export interface ImageWindowLoader {
-    setWindow(newWindow: Rectangle, freezeCols: number | [left: number, right: number], freezeRows: number[]): void;
+    setWindow(
+        newWindow: Rectangle,
+        freezeCols: number | readonly [left: number, right: number],
+        freezeRows: number[]
+    ): void;
     loadOrGetImage(url: string, col: number, row: number): HTMLImageElement | ImageBitmap | undefined;
     setCallback(imageLoaded: (locations: CellSet) => void): void;
 }

--- a/packages/core/src/internal/data-grid/render/data-grid-lib.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-lib.ts
@@ -24,6 +24,8 @@ export function useMappedColumns(
     columns: readonly InnerGridColumn[],
     freezeColumns: number | [left: number, right: number]
 ): readonly MappedGridColumn[] {
+    // Extract freeze column counts from the union type parameter. freezeColumnsLeft and freezeColumnsRight
+    // determine which columns should remain sticky at the left and right sides respectively during horizontal scrolling.
     const freezeColumnsLeft = typeof freezeColumns === "number" ? freezeColumns : freezeColumns[0];
     const freezeColumnsRight = typeof freezeColumns === "number" ? 0 : freezeColumns[1];
 

--- a/packages/core/src/internal/data-grid/render/data-grid-lib.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-lib.ts
@@ -8,7 +8,7 @@ import {
     type Rectangle,
     type BaseGridCell,
 } from "../data-grid-types.js";
-import { direction } from "../../../common/utils.js";
+import { direction, normalizeFreezeColumns } from "../../../common/utils.js";
 import React from "react";
 import type { BaseDrawArgs, PrepResult } from "../../../cells/cell-types.js";
 import { split as splitText, clearCache } from "canvas-hypertxt";
@@ -232,8 +232,7 @@ export function getEffectiveColumns(
 ): readonly MappedGridColumn[] {
     const mappedCols = remapForDnDState(columns, dndState);
 
-    const freezeLeftColumns = typeof freezeColumns === "number" ? freezeColumns : freezeColumns[0];
-    const freezeRightColumns = typeof freezeColumns === "number" ? 0 : freezeColumns[1];
+    const [freezeLeftColumns, freezeRightColumns] = normalizeFreezeColumns(freezeColumns);
 
     const sticky: MappedGridColumn[] = [];
     for (let i = 0; i < freezeLeftColumns; i++) {
@@ -829,8 +828,7 @@ export function computeBounds(
         height: 0,
     };
 
-    const freezeLeftColumns = typeof freezeColumns === "number" ? freezeColumns : freezeColumns[0];
-    const freezeRightColumns = typeof freezeColumns === "number" ? 0 : freezeColumns[1];
+    const [freezeLeftColumns, freezeRightColumns] = normalizeFreezeColumns(freezeColumns);
     const column = mappedColumns[col];
 
     if (col >= mappedColumns.length || row >= rows || row < -2 || col < 0) {

--- a/packages/core/src/internal/data-grid/render/data-grid-lib.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-lib.ts
@@ -279,7 +279,7 @@ export function getColumnIndexForX(
         const colIdx = effectiveColumns.length - 1 - fc;
         const col = effectiveColumns[colIdx];
         y -= col.width;
-        if (targetX <= y) {
+        if (targetX >= y) {
             return col.sourceIndex;
         }
     }
@@ -818,6 +818,7 @@ export function computeBounds(
 
     const freezeLeftColumns = typeof freezeColumns === "number" ? freezeColumns : freezeColumns[0];
     const freezeRightColumns = typeof freezeColumns === "number" ? 0 : freezeColumns[1];
+    const column = mappedColumns[col];
 
     if (col >= mappedColumns.length || row >= rows || row < -2 || col < 0) {
         return result;
@@ -825,16 +826,21 @@ export function computeBounds(
 
     const headerHeight = totalHeaderHeight - groupHeaderHeight;
 
-    if (col >= freezeLeftColumns) {
+    if (col >= freezeLeftColumns && col < mappedColumns.length - freezeRightColumns) {
         const dir = cellXOffset > col ? -1 : 1;
-        const [freezeLeftWidth, freezeRightWidth] = getStickyWidth(mappedColumns);
+        const [freezeLeftWidth] = getStickyWidth(mappedColumns);
         result.x += freezeLeftWidth + translateX;
         for (let i = cellXOffset; i !== col; i += dir) {
             result.x += mappedColumns[dir === 1 ? i : i - 1].width * dir;
         }
-    } else {
+    } else if (column.stickyPosition === "left") {
         for (let i = 0; i < col; i++) {
             result.x += mappedColumns[i].width;
+        }
+    } else if (column.stickyPosition === "right") {
+        result.x = width;
+        for (let i = col; i < mappedColumns.length; i++) {
+            result.x -= mappedColumns[i].width;
         }
     }
     result.width = mappedColumns[col].width + 1;
@@ -871,7 +877,7 @@ export function computeBounds(
             end++;
         }
         if (!sticky) {
-            const [freezeLeftWidth, freezeRightWidth] = getStickyWidth(mappedColumns);
+            const [freezeLeftWidth] = getStickyWidth(mappedColumns);
             const clip = result.x - freezeLeftWidth;
             if (clip < 0) {
                 result.x -= clip;

--- a/packages/core/src/internal/data-grid/render/data-grid-lib.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-lib.ts
@@ -243,6 +243,19 @@ export function getEffectiveColumns(
             width -= c.width;
         }
     }
+
+    const stickyRight: MappedGridColumn[] = [];
+
+    for (let i = mappedCols.length - freezeRightColumns; i < mappedCols.length; i++) {
+        stickyRight.push(mappedCols[i]);
+    }
+
+    if (stickyRight.length > 0) {
+        for (const c of stickyRight) {
+            width -= c.width;
+        }
+    }
+
     let endIndex = cellXOffset;
     let curX = tx ?? 0;
 
@@ -258,9 +271,7 @@ export function getEffectiveColumns(
         }
     }
 
-    for (let i = mappedCols.length - freezeRightColumns; i < mappedCols.length; i++) {
-        sticky.push(mappedCols[i]);
-    }
+    sticky.push(...stickyRight);
 
     return sticky;
 }

--- a/packages/core/src/internal/data-grid/render/data-grid-lib.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-lib.ts
@@ -17,12 +17,16 @@ import type { FullyDefined } from "../../../common/support.js";
 export interface MappedGridColumn extends FullyDefined<InnerGridColumn> {
     sourceIndex: number;
     sticky: boolean;
+    stickyPosition: "left" | "right" | undefined;
 }
 
 export function useMappedColumns(
     columns: readonly InnerGridColumn[],
-    freezeColumns: number
+    freezeColumns: number | [left: number, right: number]
 ): readonly MappedGridColumn[] {
+    const freezeColumnsLeft = typeof freezeColumns === "number" ? freezeColumns : freezeColumns[0];
+    const freezeColumnsRight = typeof freezeColumns === "number" ? 0 : freezeColumns[1];
+
     return React.useMemo(
         () =>
             columns.map(
@@ -35,7 +39,9 @@ export function useMappedColumns(
                     menuIcon: c.menuIcon,
                     overlayIcon: c.overlayIcon,
                     sourceIndex: i,
-                    sticky: i < freezeColumns,
+                    sticky: i < freezeColumnsLeft || i >= columns.length - freezeColumnsRight,
+                    stickyPosition:
+                        i < freezeColumnsLeft ? "left" : i >= columns.length - freezeColumnsRight ? "right" : undefined,
                     indicatorIcon: c.indicatorIcon,
                     style: c.style,
                     themeOverride: c.themeOverride,
@@ -50,7 +56,7 @@ export function useMappedColumns(
                     headerRowMarkerDisabled: c.headerRowMarkerDisabled,
                 })
             ),
-        [columns, freezeColumns]
+        [columns, freezeColumnsLeft, freezeColumnsRight]
     );
 }
 
@@ -174,16 +180,25 @@ export function getStickyWidth(
         src: number;
         dest: number;
     }
-): number {
-    let result = 0;
+): [left: number, right: number] {
+    let lWidth = 0;
+    let rWidth = 0;
     const remapped = remapForDnDState(columns, dndState);
     for (let i = 0; i < remapped.length; i++) {
         const c = remapped[i];
-        if (c.sticky) result += c.width;
-        else break;
+        if (c.sticky) {
+            if (c.stickyPosition === "left") lWidth += c.width;
+        } else break;
     }
 
-    return result;
+    for (let i = remapped.length - 1; i >= 0; i--) {
+        const c = remapped[i];
+        if (c.sticky) {
+            if (c.stickyPosition === "right") rWidth += c.width;
+        } else break;
+    }
+
+    return [lWidth, rWidth];
 }
 
 export function getFreezeTrailingHeight(
@@ -206,6 +221,7 @@ export function getEffectiveColumns(
     columns: readonly MappedGridColumn[],
     cellXOffset: number,
     width: number,
+    freezeColumns: number | [left: number, right: number],
     dndState?: {
         src: number;
         dest: number;
@@ -214,14 +230,14 @@ export function getEffectiveColumns(
 ): readonly MappedGridColumn[] {
     const mappedCols = remapForDnDState(columns, dndState);
 
+    const freezeLeftColumns = typeof freezeColumns === "number" ? freezeColumns : freezeColumns[0];
+    const freezeRightColumns = typeof freezeColumns === "number" ? 0 : freezeColumns[1];
+
     const sticky: MappedGridColumn[] = [];
-    for (const c of mappedCols) {
-        if (c.sticky) {
-            sticky.push(c);
-        } else {
-            break;
-        }
+    for (let i = 0; i < freezeLeftColumns; i++) {
+        sticky.push(mappedCols[i]);
     }
+
     if (sticky.length > 0) {
         for (const c of sticky) {
             width -= c.width;
@@ -242,22 +258,42 @@ export function getEffectiveColumns(
         }
     }
 
+    for (let i = mappedCols.length - freezeRightColumns; i < mappedCols.length; i++) {
+        sticky.push(mappedCols[i]);
+    }
+
     return sticky;
 }
 
 export function getColumnIndexForX(
     targetX: number,
     effectiveColumns: readonly MappedGridColumn[],
+    freezeColumns: number | [left: number, right: number],
+    width: number,
     translateX?: number
 ): number {
+    const freezeRightColumns = typeof freezeColumns === "number" ? 0 : freezeColumns[1];
+
+    let y = width;
+    for (let fc = 0; fc < freezeRightColumns; fc++) {
+        const colIdx = effectiveColumns.length - 1 - fc;
+        const col = effectiveColumns[colIdx];
+        y -= col.width;
+        if (targetX <= y) {
+            return col.sourceIndex;
+        }
+    }
+
     let x = 0;
-    for (const c of effectiveColumns) {
+    for (let i = 0; i < effectiveColumns.length - freezeRightColumns; i++) {
+        const c = effectiveColumns[i];
         const cx = c.sticky ? x : x + (translateX ?? 0);
         if (targetX <= cx + c.width) {
             return c.sourceIndex;
         }
         x += c.width;
     }
+
     return -1;
 }
 
@@ -768,7 +804,7 @@ export function computeBounds(
     translateX: number,
     translateY: number,
     rows: number,
-    freezeColumns: number,
+    freezeColumns: number | [left: number, right: number],
     freezeTrailingRows: number,
     mappedColumns: readonly MappedGridColumn[],
     rowHeight: number | ((index: number) => number)
@@ -780,16 +816,19 @@ export function computeBounds(
         height: 0,
     };
 
+    const freezeLeftColumns = typeof freezeColumns === "number" ? freezeColumns : freezeColumns[0];
+    const freezeRightColumns = typeof freezeColumns === "number" ? 0 : freezeColumns[1];
+
     if (col >= mappedColumns.length || row >= rows || row < -2 || col < 0) {
         return result;
     }
 
     const headerHeight = totalHeaderHeight - groupHeaderHeight;
 
-    if (col >= freezeColumns) {
+    if (col >= freezeLeftColumns) {
         const dir = cellXOffset > col ? -1 : 1;
-        const freezeWidth = getStickyWidth(mappedColumns);
-        result.x += freezeWidth + translateX;
+        const [freezeLeftWidth, freezeRightWidth] = getStickyWidth(mappedColumns);
+        result.x += freezeLeftWidth + translateX;
         for (let i = cellXOffset; i !== col; i += dir) {
             result.x += mappedColumns[dir === 1 ? i : i - 1].width * dir;
         }
@@ -832,8 +871,8 @@ export function computeBounds(
             end++;
         }
         if (!sticky) {
-            const freezeWidth = getStickyWidth(mappedColumns);
-            const clip = result.x - freezeWidth;
+            const [freezeLeftWidth, freezeRightWidth] = getStickyWidth(mappedColumns);
+            const clip = result.x - freezeLeftWidth;
             if (clip < 0) {
                 result.x -= clip;
                 result.width += clip;

--- a/packages/core/src/internal/data-grid/render/data-grid-lib.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-lib.ts
@@ -22,7 +22,7 @@ export interface MappedGridColumn extends FullyDefined<InnerGridColumn> {
 
 export function useMappedColumns(
     columns: readonly InnerGridColumn[],
-    freezeColumns: number | [left: number, right: number]
+    freezeColumns: number | readonly [left: number, right: number]
 ): readonly MappedGridColumn[] {
     // Extract freeze column counts from the union type parameter. freezeColumnsLeft and freezeColumnsRight
     // determine which columns should remain sticky at the left and right sides respectively during horizontal scrolling.
@@ -223,7 +223,7 @@ export function getEffectiveColumns(
     columns: readonly MappedGridColumn[],
     cellXOffset: number,
     width: number,
-    freezeColumns: number | [left: number, right: number],
+    freezeColumns: number | readonly [left: number, right: number],
     dndState?: {
         src: number;
         dest: number;
@@ -281,7 +281,7 @@ export function getEffectiveColumns(
 export function getColumnIndexForX(
     targetX: number,
     effectiveColumns: readonly MappedGridColumn[],
-    freezeColumns: number | [left: number, right: number],
+    freezeColumns: number | readonly [left: number, right: number],
     width: number,
     translateX?: number
 ): number {
@@ -817,7 +817,7 @@ export function computeBounds(
     translateX: number,
     translateY: number,
     rows: number,
-    freezeColumns: number | [left: number, right: number],
+    freezeColumns: number | readonly [left: number, right: number],
     freezeTrailingRows: number,
     mappedColumns: readonly MappedGridColumn[],
     rowHeight: number | ((index: number) => number)

--- a/packages/core/src/internal/data-grid/render/data-grid-render.blit.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.blit.ts
@@ -70,7 +70,7 @@ export function blitLastFrame(
     }
     deltaX += translateX - last.translateX;
 
-    const stickyWidth = getStickyWidth(effectiveCols);
+    const [stickyLeftWidth, stickyRightWidth] = getStickyWidth(effectiveCols);
 
     if (deltaX !== 0 && deltaY !== 0) {
         return {
@@ -81,7 +81,7 @@ export function blitLastFrame(
     const freezeTrailingRowsHeight =
         freezeTrailingRows > 0 ? getFreezeTrailingHeight(rows, freezeTrailingRows, getRowHeight) : 0;
 
-    const blitWidth = width - stickyWidth - Math.abs(deltaX);
+    const blitWidth = width - stickyLeftWidth - Math.abs(deltaX) - stickyRightWidth;
     const blitHeight = height - totalHeaderHeight - freezeTrailingRowsHeight - Math.abs(deltaY) - 1;
 
     if (blitWidth > 150 && blitHeight > 150) {
@@ -128,22 +128,22 @@ export function blitLastFrame(
         // blit X
         if (deltaX > 0) {
             // pixels moving right
-            args.sx = stickyWidth * dpr;
+            args.sx = stickyLeftWidth * dpr;
             args.sw = blitWidth * dpr;
-            args.dx = (deltaX + stickyWidth) * dpr;
+            args.dx = (deltaX + stickyLeftWidth) * dpr;
             args.dw = blitWidth * dpr;
 
             drawRegions.push({
-                x: stickyWidth - 1,
+                x: stickyLeftWidth - 1,
                 y: 0,
                 width: deltaX + 2, // extra width to account for first col not drawing a left side border
                 height: height,
             });
         } else if (deltaX < 0) {
             // pixels moving left
-            args.sx = (stickyWidth - deltaX) * dpr;
+            args.sx = (stickyLeftWidth - deltaX) * dpr;
             args.sw = blitWidth * dpr;
-            args.dx = stickyWidth * dpr;
+            args.dx = stickyLeftWidth * dpr;
             args.dw = blitWidth * dpr;
 
             drawRegions.push({
@@ -157,14 +157,14 @@ export function blitLastFrame(
         ctx.setTransform(1, 0, 0, 1, 0, 0);
         if (doubleBuffer) {
             if (
-                stickyWidth > 0 &&
+                stickyLeftWidth > 0 &&
                 deltaX !== 0 &&
                 deltaY === 0 &&
                 (targetScroll === undefined || blitSourceScroll?.[1] !== false)
             ) {
                 // When double buffering the freeze columns can be offset by a couple pixels vertically between the two
                 // buffers. We don't want to redraw them so we need to make sure to copy them between the buffers.
-                const w = stickyWidth * dpr;
+                const w = stickyLeftWidth * dpr;
                 const h = height * dpr;
                 ctx.drawImage(blitSource, 0, 0, w, h, 0, 0, w, h);
             }
@@ -200,7 +200,8 @@ export function blitResizedCol(
     height: number,
     totalHeaderHeight: number,
     effectiveCols: readonly MappedGridColumn[],
-    resizedIndex: number
+    resizedIndex: number,
+    freezeTrailingColumns: number
 ) {
     const drawRegions: Rectangle[] = [];
 
@@ -215,18 +216,27 @@ export function blitResizedCol(
         return drawRegions;
     }
 
-    walkColumns(effectiveCols, cellYOffset, translateX, translateY, totalHeaderHeight, (c, drawX, _drawY, clipX) => {
-        if (c.sourceIndex === resizedIndex) {
-            const x = Math.max(drawX, clipX) + 1;
-            drawRegions.push({
-                x,
-                y: 0,
-                width: width - x,
-                height,
-            });
-            return true;
+    walkColumns(
+        effectiveCols,
+        width,
+        cellYOffset,
+        translateX,
+        translateY,
+        totalHeaderHeight,
+        freezeTrailingColumns,
+        (c, drawX, _drawY, clipX) => {
+            if (c.sourceIndex === resizedIndex) {
+                const x = Math.max(drawX, clipX) + 1;
+                drawRegions.push({
+                    x,
+                    y: 0,
+                    width: width - x,
+                    height,
+                });
+                return true;
+            }
         }
-    });
+    );
     return drawRegions;
 }
 

--- a/packages/core/src/internal/data-grid/render/data-grid-render.blit.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.blit.ts
@@ -147,9 +147,9 @@ export function blitLastFrame(
             args.dw = blitWidth * dpr;
 
             drawRegions.push({
-                x: width + deltaX,
+                x: width + deltaX - stickyRightWidth,
                 y: 0,
-                width: -deltaX,
+                width: -deltaX + stickyRightWidth,
                 height: height,
             });
         }
@@ -167,6 +167,17 @@ export function blitLastFrame(
                 const w = stickyLeftWidth * dpr;
                 const h = height * dpr;
                 ctx.drawImage(blitSource, 0, 0, w, h, 0, 0, w, h);
+            }
+            if (
+                stickyRightWidth > 0 &&
+                deltaX !== 0 &&
+                deltaY === 0 &&
+                (targetScroll === undefined || blitSourceScroll?.[1] !== false)
+            ) {
+                const x = (width - stickyRightWidth) * dpr;
+                const w = stickyRightWidth * dpr;
+                const h = height * dpr;
+                ctx.drawImage(blitSource, x, 0, w, h, x, 0, w, h);
             }
             if (
                 freezeTrailingRowsHeight > 0 &&

--- a/packages/core/src/internal/data-grid/render/data-grid-render.cells.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.cells.ts
@@ -77,6 +77,7 @@ export function drawCells(
     effectiveColumns: readonly MappedGridColumn[],
     allColumns: readonly MappedGridColumn[],
     height: number,
+    width: number,
     totalHeaderHeight: number,
     translateX: number,
     translateY: number,
@@ -90,6 +91,7 @@ export function drawCells(
     isFocused: boolean,
     drawFocus: boolean,
     freezeTrailingRows: number,
+    freezeTrailingColumns: number,
     hasAppendRow: boolean,
     drawRegions: readonly Rectangle[],
     damage: CellSet | undefined,
@@ -124,10 +126,12 @@ export function drawCells(
 
     walkColumns(
         effectiveColumns,
+        width,
         cellYOffset,
         translateX,
         translateY,
         totalHeaderHeight,
+        freezeTrailingColumns,
         (c, drawX, colDrawStartY, clipX, startRow) => {
             const diff = Math.max(0, clipX - drawX);
 

--- a/packages/core/src/internal/data-grid/render/data-grid-render.cells.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.cells.ts
@@ -299,7 +299,7 @@ export function drawCells(
 
                     const bgCell = cell.kind === GridCellKind.Protected ? theme.bgCellMedium : theme.bgCell;
                     let fill: string | undefined;
-                    if (isSticky || bgCell !== outerTheme.bgCell) {
+                    if (isSticky || bgCell !== outerTheme.bgCell || c.sticky) {
                         fill = blend(bgCell, fill);
                     }
 

--- a/packages/core/src/internal/data-grid/render/data-grid-render.cells.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.cells.ts
@@ -132,12 +132,12 @@ export function drawCells(
         translateY,
         totalHeaderHeight,
         freezeTrailingColumns,
-        (c, drawX, colDrawStartY, clipX, startRow) => {
+        (c, drawX, colDrawStartY, clipX, clipXRight, startRow) => {
             const diff = Math.max(0, clipX - drawX);
 
             const colDrawX = drawX + diff;
             const colDrawY = totalHeaderHeight + 1;
-            const colWidth = c.width - diff;
+            const colWidth = c.stickyPosition === "right" ? c.width - diff : Math.min(c.width - diff, width - drawX - clipXRight);
             const colHeight = height - totalHeaderHeight - 1;
             if (drawRegions.length > 0) {
                 let found = false;
@@ -555,11 +555,11 @@ export function drawCell(
             partialPrepResult === undefined
                 ? undefined
                 : {
-                      deprep: partialPrepResult?.deprep,
-                      fillStyle: partialPrepResult?.fillStyle,
-                      font: partialPrepResult?.font,
-                      renderer: r,
-                  };
+                    deprep: partialPrepResult?.deprep,
+                    fillStyle: partialPrepResult?.fillStyle,
+                    font: partialPrepResult?.font,
+                    renderer: r,
+                };
     }
 
     if (needsAnim || animationFrameRequested) enqueue?.(allocatedItem);

--- a/packages/core/src/internal/data-grid/render/data-grid-render.cells.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.cells.ts
@@ -256,8 +256,15 @@ export function drawCells(
                                 drawingSpan = true;
                             }
                         } else {
-                            toDraw--;
-                            return;
+                            // Frozen trailing rows: fall through with skipContents=true so each column
+                            // repaints its own fill (overwriting scrolling-row overflow past freezeY
+                            // and applying per-column selection/highlight). Content stays drawn once
+                            // by the span push above. Non-frozen spans keep the short-circuit.
+                            if (!isSticky) {
+                                toDraw--;
+                                return;
+                            }
+                            skipContents = true;
                         }
                     }
 

--- a/packages/core/src/internal/data-grid/render/data-grid-render.cells.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.cells.ts
@@ -256,15 +256,8 @@ export function drawCells(
                                 drawingSpan = true;
                             }
                         } else {
-                            // Frozen trailing rows: fall through with skipContents=true so each column
-                            // repaints its own fill (overwriting scrolling-row overflow past freezeY
-                            // and applying per-column selection/highlight). Content stays drawn once
-                            // by the span push above. Non-frozen spans keep the short-circuit.
-                            if (!isSticky) {
-                                toDraw--;
-                                return;
-                            }
-                            skipContents = true;
+                            toDraw--;
+                            return;
                         }
                     }
 
@@ -364,6 +357,35 @@ export function drawCells(
                         fill = fill === undefined ? theme.bgCell : blend(fill, theme.bgCell);
                     }
 
+                    // Full-redraw counterpart to the damage-path clamp above. Columns draw left-to-right and
+                    // each paints its scrolling rows before the next column runs, so a scrolling row whose
+                    // bottom crosses into the frozen band would overwrite a spanning frozen row that an
+                    // earlier column already drew. Clip such straddling rows to the freeze boundary so the
+                    // frozen band stays reserved for frozen rows only.
+                    //
+                    // Exception: a span drawn by a sticky (frozen) column — e.g. a group-header row whose
+                    // label lives in the frozen columns. Sticky columns are re-composited over the blitted
+                    // frame every draw, and clipping that composite to the freeze boundary leaves the group
+                    // row's background a shade darker than its scrollable half (a visible two-tone seam that
+                    // accumulates while scrolling). Such a straddling group span doesn't need the clip anyway:
+                    // the frozen trailing rows are painted afterwards in each column's sticky pass and cover
+                    // any bleed. So skip the clip for sticky spans; keep it for sticky non-span cells (which
+                    // still must not bleed into the band) and for all scrollable cells.
+                    let didFreezeClip = false;
+                    if (
+                        damage === undefined &&
+                        !isSticky &&
+                        !(c.sticky && drawingSpan) &&
+                        freezeTrailingRowsHeight > 0 &&
+                        drawY + rh > height - freezeTrailingRowsHeight
+                    ) {
+                        didFreezeClip = true;
+                        ctx.save();
+                        ctx.beginPath();
+                        ctx.rect(cellX, drawY, cellWidth, height - freezeTrailingRowsHeight - drawY);
+                        ctx.clip();
+                    }
+
                     const isLastColumn = c.sourceIndex === allColumns.length - 1;
                     const isLastRow = row === rows - 1;
                     if (fill !== undefined) {
@@ -434,6 +456,10 @@ export function drawCells(
                     }
 
                     if (didDamageClip) {
+                        ctx.restore();
+                    }
+
+                    if (didFreezeClip) {
                         ctx.restore();
                     }
 

--- a/packages/core/src/internal/data-grid/render/data-grid-render.cells.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.cells.ts
@@ -260,8 +260,15 @@ export function drawCells(
                                 drawingSpan = true;
                             }
                         } else {
-                            toDraw--;
-                            return;
+                            // Frozen trailing rows: fall through with skipContents=true so each column
+                            // repaints its own fill (overwriting scrolling-row overflow past freezeY
+                            // and applying per-column selection/highlight). Content stays drawn once
+                            // by the span push above. Non-frozen spans keep the short-circuit.
+                            if (!isSticky) {
+                                toDraw--;
+                                return;
+                            }
+                            skipContents = true;
                         }
                     }
 

--- a/packages/core/src/internal/data-grid/render/data-grid-render.header.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.header.ts
@@ -38,7 +38,8 @@ export function drawGridHeaders(
     getGroupDetails: GroupDetailsCallback,
     damage: CellSet | undefined,
     drawHeaderCallback: DrawHeaderCallback | undefined,
-    touchMode: boolean
+    touchMode: boolean,
+    freezeTrailingColumns: number
 ) {
     const totalHeaderHeight = headerHeight + groupHeaderHeight;
     if (totalHeaderHeight <= 0) return;
@@ -54,7 +55,7 @@ export function drawGridHeaders(
     const font = outerTheme.headerFontFull;
     // Assinging the context font too much can be expensive, it can be worth it to minimze this
     ctx.font = font;
-    walkColumns(effectiveCols, 0, translateX, 0, totalHeaderHeight, (c, x, _y, clipX) => {
+    walkColumns(effectiveCols, width, 0, translateX, 0, totalHeaderHeight, freezeTrailingColumns, (c, x, _y, clipX) => {
         if (damage !== undefined && !damage.has([c.sourceIndex, -1])) return;
         const diff = Math.max(0, clipX - x);
         ctx.save();

--- a/packages/core/src/internal/data-grid/render/data-grid-render.header.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.header.ts
@@ -69,6 +69,11 @@ export function drawGridHeaders(
                 ? outerTheme
                 : mergeAndRealizeTheme(outerTheme, groupTheme, c.themeOverride);
 
+        if (c.sticky) {
+            ctx.fillStyle = theme.bgHeader;
+            ctx.fill();
+        }
+
         if (theme.bgHeader !== outerTheme.bgHeader) {
             ctx.fillStyle = theme.bgHeader;
             ctx.fill();

--- a/packages/core/src/internal/data-grid/render/data-grid-render.lines.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.lines.ts
@@ -331,6 +331,7 @@ export function drawGridLines(
     for (let index = 0; index < effectiveCols.length; index++) {
         const c = effectiveCols[index];
         if (c.width === 0) continue;
+        if (c.sticky && c.stickyPosition !== "left") break;
         x += c.width;
         const tx = c.sticky ? x : x + translateX;
         if (tx >= minX && tx <= maxX && verticalBorder(index + 1)) {
@@ -344,23 +345,23 @@ export function drawGridLines(
         }
     }
 
-    // let rightX = 0.5;
-    // for (let index = effectiveCols.length - 1; index >= 0; index--) {
-    //     const c = effectiveCols[index];
-    //     if (c.width === 0) continue;
-    //     if (!c.sticky) break;
-    //     rightX += c.width;
-    //     const tx = c.sticky ? rightX : rightX + translateX;
-    //     if (tx >= minX && tx <= maxX && verticalBorder(index + 1)) {
-    //         toDraw.push({
-    //             x1: tx,
-    //             y1: Math.max(groupHeaderHeight, minY),
-    //             x2: tx,
-    //             y2: Math.min(height, maxY),
-    //             color: vColor,
-    //         });
-    //     }
-    // }
+    let rightX = width + 0.5;
+    for (let index = effectiveCols.length - 1; index >= 0; index--) {
+        const c = effectiveCols[index];
+        if (c.width === 0) continue;
+        if (!c.sticky) break;
+        rightX -= c.width;
+        const tx = rightX;
+        if (tx >= minX && tx <= maxX && verticalBorder(index + 1)) {
+            toDraw.push({
+                x1: tx,
+                y1: Math.max(groupHeaderHeight, minY),
+                x2: tx,
+                y2: Math.min(height, maxY),
+                color: vColor,
+            });
+        }
+    }
 
     let freezeY = height + 0.5;
     for (let i = rows - freezeTrailingRows; i < rows; i++) {

--- a/packages/core/src/internal/data-grid/render/data-grid-render.lines.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.lines.ts
@@ -317,6 +317,8 @@ export function drawGridLines(
         }
         ctx.clip("evenodd");
     }
+
+    const effectiveWidth = effectiveCols.reduce((acc, col) => acc + col.width, 0);
     const hColor = theme.horizontalBorderColor ?? theme.borderColor;
     const vColor = theme.borderColor;
 
@@ -345,6 +347,7 @@ export function drawGridLines(
         }
     }
 
+    width = Math.min(width, effectiveWidth);
     let rightX = width + 0.5;
     for (let index = effectiveCols.length - 1; index >= 0; index--) {
         const c = effectiveCols[index];

--- a/packages/core/src/internal/data-grid/render/data-grid-render.lines.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.lines.ts
@@ -347,8 +347,8 @@ export function drawGridLines(
         }
     }
 
-    width = Math.min(width, effectiveWidth);
-    let rightX = width + 0.5;
+    const clippedWidth = Math.min(width, effectiveWidth);
+    let rightX = clippedWidth + 0.5;
     for (let index = effectiveCols.length - 1; index >= 0; index--) {
         const c = effectiveCols[index];
         if (c.width === 0) continue;

--- a/packages/core/src/internal/data-grid/render/data-grid-render.lines.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.lines.ts
@@ -48,7 +48,7 @@ export function drawBlanks(
         translateY,
         totalHeaderHeight,
         freezeTrailingColumns,
-        (c, drawX, colDrawY, clipX, startRow) => {
+        (c, drawX, colDrawY, clipX, _clipXRight, startRow) => {
             if (c !== effectiveColumns[effectiveColumns.length - 1]) return;
             drawX += c.width;
             const x = Math.max(drawX, clipX);
@@ -331,7 +331,7 @@ export function drawGridLines(
     for (let index = 0; index < effectiveCols.length; index++) {
         const c = effectiveCols[index];
         if (c.width === 0) continue;
-        if (c.sticky && c.stickyPosition !== "left") break;
+        if (effectiveCols[index + 1]?.sticky && effectiveCols[index + 1].stickyPosition !== "left") break;
         x += c.width;
         const tx = c.sticky ? x : x + translateX;
         if (tx >= minX && tx <= maxX && verticalBorder(index + 1)) {

--- a/packages/core/src/internal/data-grid/render/data-grid-render.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.ts
@@ -418,6 +418,18 @@ export function drawGrid(arg: DrawGridArg, lastArg: DrawGridArg | undefined) {
                 height: freezeTrailingRows,
                 when: freezeTrailingRows > 0,
             },
+            {
+                x: viewRegionWidth - freezeRightColumns,
+                y: cellYOffset,
+                width: freezeRightColumns,
+                height: 300,
+            },
+            {
+                x: viewRegionWidth - freezeRightColumns,
+                y: -2,
+                width: freezeRightColumns,
+                height: 2,
+            },
         ]);
 
         const doDamage = (ctx: CanvasRenderingContext2D) => {

--- a/packages/core/src/internal/data-grid/render/data-grid-render.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.ts
@@ -71,7 +71,10 @@ function clipHeaderDamage(
             const diff = Math.max(0, clipX - drawX);
 
             const finalX = drawX + diff + 1;
-            const finalWidth = c.stickyPosition === "right" ? c.width - diff : Math.min(c.width - diff - 1, width - drawX - clipXRight); // c.width - diff - 1;
+            const finalWidth =
+                c.stickyPosition === "right"
+                    ? c.width - diff
+                    : Math.min(c.width - diff - 1, width - drawX - clipXRight);
             if (damage.has([c.sourceIndex, -1])) {
                 ctx.rect(finalX, groupHeaderHeight, finalWidth, totalHeaderHeight - groupHeaderHeight);
             }
@@ -631,25 +634,25 @@ export function drawGrid(arg: DrawGridArg, lastArg: DrawGridArg | undefined) {
     // the overdraw may have nuked out our focus ring right edge.
     const focusRedraw = drawFocus
         ? drawFillHandle(
-            targetCtx,
-            width,
-            height,
-            cellYOffset,
-            translateX,
-            translateY,
-            effectiveCols,
-            mappedColumns,
-            theme,
-            totalHeaderHeight,
-            selection,
-            getRowHeight,
-            getCellContent,
-            freezeTrailingRows,
-            freezeRightColumns,
-            hasAppendRow,
-            fillHandle,
-            rows
-        )
+              targetCtx,
+              width,
+              height,
+              cellYOffset,
+              translateX,
+              translateY,
+              effectiveCols,
+              mappedColumns,
+              theme,
+              totalHeaderHeight,
+              selection,
+              getRowHeight,
+              getCellContent,
+              freezeTrailingRows,
+              freezeRightColumns,
+              hasAppendRow,
+              fillHandle,
+              rows
+          )
         : undefined;
 
     targetCtx.fillStyle = theme.bgCell;
@@ -823,7 +826,8 @@ export function drawGrid(arg: DrawGridArg, lastArg: DrawGridArg | undefined) {
             height: lastRowDrawn - cellYOffset,
         },
         freezeColumns,
-        Array.from({ length: freezeTrailingRows }, (_, i) => rows - 1 - i)
+        Array.from({ length: freezeTrailingRows }, (_, i) => rows - 1 - i),
+        mappedColumns.length
     );
 
     const scrollX = last !== undefined && (cellXOffset !== last.cellXOffset || translateX !== last.translateX);

--- a/packages/core/src/internal/data-grid/render/data-grid-render.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.ts
@@ -40,17 +40,24 @@ function clipHeaderDamage(
 
     ctx.beginPath();
 
-    walkGroups(effectiveColumns, width, translateX, groupHeaderHeight, (span, _group, x, y, w, h) => {
-        const hasItemInSpan = damage.hasItemInRectangle({
-            x: span[0],
-            y: -2,
-            width: span[1] - span[0] + 1,
-            height: 1,
-        });
-        if (hasItemInSpan) {
-            ctx.rect(x, y, w, h);
+    walkGroups(
+        effectiveColumns,
+        width,
+        translateX,
+        groupHeaderHeight,
+        freezeTrailingColumns,
+        (span, _group, x, y, w, h) => {
+            const hasItemInSpan = damage.hasItemInRectangle({
+                x: span[0],
+                y: -2,
+                width: span[1] - span[0] + 1,
+                height: 1,
+            });
+            if (hasItemInSpan) {
+                ctx.rect(x, y, w, h);
+            }
         }
-    });
+    );
 
     walkColumns(
         effectiveColumns,
@@ -60,11 +67,11 @@ function clipHeaderDamage(
         translateY,
         totalHeaderHeight,
         freezeTrailingColumns,
-        (c, drawX, _colDrawY, clipX) => {
+        (c, drawX, _colDrawY, clipX, clipXRight) => {
             const diff = Math.max(0, clipX - drawX);
 
             const finalX = drawX + diff + 1;
-            const finalWidth = c.width - diff - 1;
+            const finalWidth = c.stickyPosition === "right" ? c.width - diff : Math.min(c.width - diff - 1, width - drawX - clipXRight); // c.width - diff - 1;
             if (damage.has([c.sourceIndex, -1])) {
                 ctx.rect(finalX, groupHeaderHeight, finalWidth, totalHeaderHeight - groupHeaderHeight);
             }
@@ -96,7 +103,7 @@ function getLastRow(
         translateY,
         totalHeaderHeight,
         freezeTrailingColumns,
-        (_c, __drawX, colDrawY, _clipX, startRow) => {
+        (_c, __drawX, colDrawY, _clipX, _clipXRight, startRow) => {
             walkRowsInCol(
                 startRow,
                 colDrawY,
@@ -624,25 +631,25 @@ export function drawGrid(arg: DrawGridArg, lastArg: DrawGridArg | undefined) {
     // the overdraw may have nuked out our focus ring right edge.
     const focusRedraw = drawFocus
         ? drawFillHandle(
-              targetCtx,
-              width,
-              height,
-              cellYOffset,
-              translateX,
-              translateY,
-              effectiveCols,
-              mappedColumns,
-              theme,
-              totalHeaderHeight,
-              selection,
-              getRowHeight,
-              getCellContent,
-              freezeTrailingRows,
-              freezeRightColumns,
-              hasAppendRow,
-              fillHandle,
-              rows
-          )
+            targetCtx,
+            width,
+            height,
+            cellYOffset,
+            translateX,
+            translateY,
+            effectiveCols,
+            mappedColumns,
+            theme,
+            totalHeaderHeight,
+            selection,
+            getRowHeight,
+            getCellContent,
+            freezeTrailingRows,
+            freezeRightColumns,
+            hasAppendRow,
+            fillHandle,
+            rows
+        )
         : undefined;
 
     targetCtx.fillStyle = theme.bgCell;

--- a/packages/core/src/internal/data-grid/render/data-grid-render.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.ts
@@ -12,6 +12,7 @@ import { drawGridHeaders } from "./data-grid-render.header.js";
 import { drawGridLines, overdrawStickyBoundaries, drawBlanks, drawExtraRowThemes } from "./data-grid-render.lines.js";
 import { blitLastFrame, blitResizedCol, computeCanBlit } from "./data-grid-render.blit.js";
 import { drawHighlightRings, drawFillHandle, drawColumnResizeOutline } from "./data-grid.render.rings.js";
+import { normalizeFreezeColumns } from "../../../common/utils.js";
 
 // Future optimization opportunities
 // - Create a cache of a buffer used to render the full view of a partially displayed column so that when
@@ -188,8 +189,7 @@ export function drawGrid(arg: DrawGridArg, lastArg: DrawGridArg | undefined) {
     const doubleBuffer = renderStrategy === "double-buffer";
     const dpr = Math.min(maxScaleFactor, Math.ceil(window.devicePixelRatio ?? 1));
 
-    const freezeLeftColumns = typeof freezeColumns === "number" ? freezeColumns : freezeColumns[0];
-    const freezeRightColumns = typeof freezeColumns === "number" ? 0 : freezeColumns[1];
+    const [freezeLeftColumns, freezeRightColumns] = normalizeFreezeColumns(freezeColumns);
 
     // if we are double buffering we need to make sure we can blit. If we can't we need to redraw the whole thing
     const canBlit = renderStrategy !== "direct" && computeCanBlit(arg, lastArg);

--- a/packages/core/src/internal/data-grid/render/data-grid-render.walk.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.walk.ts
@@ -65,16 +65,20 @@ export type WalkColsCallback = (
 
 export function walkColumns(
     effectiveCols: readonly MappedGridColumn[],
+    width: number,
     cellYOffset: number,
     translateX: number,
     translateY: number,
     totalHeaderHeight: number,
+    freezeTrailingColumns: number,
     cb: WalkColsCallback
 ): void {
     let x = 0;
     let clipX = 0; // this tracks the total width of sticky cols
     const drawY = totalHeaderHeight + translateY;
-    for (const c of effectiveCols) {
+
+    for (let i = 0; i < effectiveCols.length - freezeTrailingColumns; i++) {
+        const c = effectiveCols[i];
         const drawX = c.sticky ? clipX : x + translateX;
         if (cb(c, drawX, drawY, c.sticky ? 0 : clipX, cellYOffset) === true) {
             break;
@@ -82,6 +86,15 @@ export function walkColumns(
 
         x += c.width;
         clipX += c.sticky ? c.width : 0;
+    }
+
+    x = width;
+    for (let fc = 0; fc < freezeTrailingColumns; fc++) {
+        const c = effectiveCols[effectiveCols.length - 1 - fc];
+        const drawX = x - c.width;
+
+        x -= c.width;
+        cb(c, drawX, drawY, clipX, cellYOffset);
     }
 }
 

--- a/packages/core/src/internal/data-grid/render/data-grid-render.walk.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.walk.ts
@@ -1,5 +1,5 @@
 import { type Item, type Rectangle } from "../data-grid-types.js";
-import { type MappedGridColumn, isGroupEqual } from "./data-grid-lib.js";
+import { type MappedGridColumn, isGroupEqual, getFreezeTrailingHeight } from "./data-grid-lib.js";
 
 export function getSkipPoint(drawRegions: readonly Rectangle[]): number | undefined {
     if (drawRegions.length === 0) return undefined;
@@ -33,8 +33,15 @@ export function walkRowsInCol(
     let y = drawY;
     let row = startRow;
     const rowEnd = rows - freezeTrailingRows;
+    // Trailing frozen rows always occupy the bottom `getFreezeTrailingHeight(...)` pixels of the
+    // canvas, anchored to `height`. The scrollable loop below must stop at that boundary instead
+    // of at the raw `height` — otherwise, whenever `height` isn't an exact multiple of the row
+    // heights (the common case), ordinary rows spill into the space reserved for the frozen rows
+    // and can get repainted on top of them by a later damage/animation-driven redraw.
+    const freezeY =
+        freezeTrailingRows > 0 ? height - getFreezeTrailingHeight(rows, freezeTrailingRows, getRowHeight) : height;
     let didBreak = false;
-    while (y < height && row < rowEnd) {
+    while (y < freezeY && row < rowEnd) {
         const rh = getRowHeight(row);
         if (y + rh > skipToY && cb(y, row, rh, false, hasAppendRow && row === rows - 1) === true) {
             didBreak = true;

--- a/packages/core/src/internal/data-grid/render/data-grid.render.rings.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid.render.rings.ts
@@ -69,22 +69,22 @@ export function drawHighlightRings(
                 rect.width === 1 && rect.height === 1
                     ? topLeftBounds
                     : computeBounds(
-                          rect.x + rect.width - 1,
-                          rect.y + rect.height - 1,
-                          width,
-                          height,
-                          groupHeaderHeight,
-                          headerHeight + groupHeaderHeight,
-                          cellXOffset,
-                          cellYOffset,
-                          translateX,
-                          translateY,
-                          rows,
-                          freezeColumns,
-                          freezeTrailingRows,
-                          mappedColumns,
-                          rowHeight
-                      );
+                        rect.x + rect.width - 1,
+                        rect.y + rect.height - 1,
+                        width,
+                        height,
+                        groupHeaderHeight,
+                        headerHeight + groupHeaderHeight,
+                        cellXOffset,
+                        cellYOffset,
+                        translateX,
+                        translateY,
+                        rows,
+                        freezeColumns,
+                        freezeTrailingRows,
+                        mappedColumns,
+                        rowHeight
+                    );
 
             if (rect.x + rect.width >= mappedColumns.length) {
                 bottomRightBounds.width -= 1;
@@ -237,8 +237,7 @@ export function drawFillHandle(
         translateY,
         totalHeaderHeight,
         freezeTrailingColumns,
-        (col, drawX, colDrawY, clipX, startRow) => {
-            clipX;
+        (col, drawX, colDrawY, clipX, _clipXRight, startRow) => {
             if (col.sticky && targetCol > col.sourceIndex) return;
 
             const isBeforeTarget = col.sourceIndex < targetColSpan[0];

--- a/packages/core/src/internal/data-grid/render/data-grid.render.rings.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid.render.rings.ts
@@ -34,8 +34,13 @@ export function drawHighlightRings(
 
     const [freezeLeft, freezeRight] = getStickyWidth(mappedColumns);
     const freezeBottom = getFreezeTrailingHeight(rows, freezeTrailingRows, rowHeight);
-    const splitIndices = [freezeLeftColumns, 0, mappedColumns.length, rows - freezeTrailingRows] as const;
-    const splitLocations = [freezeLeft, 0, width, height - freezeBottom] as const;
+    const splitIndices = [
+        freezeLeftColumns,
+        0,
+        mappedColumns.length - freezeRightColumns,
+        rows - freezeTrailingRows,
+    ] as const;
+    const splitLocations = [freezeLeft, 0, width - freezeRight, height - freezeBottom] as const;
 
     const drawRects = highlightRegions.map(h => {
         const r = h.range;

--- a/packages/core/src/internal/data-grid/render/data-grid.render.rings.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid.render.rings.ts
@@ -7,6 +7,7 @@ import { blend, withAlpha } from "../color-parser.js";
 import { hugRectToTarget, intersectRect, rectContains, splitRectIntoRegions } from "../../../common/math.js";
 import { getSpanBounds, walkColumns, walkRowsInCol } from "./data-grid-render.walk.js";
 import { type Highlight } from "./data-grid-render.cells.js";
+import { normalizeFreezeColumns } from "../../../common/utils.js";
 
 export function drawHighlightRings(
     ctx: CanvasRenderingContext2D,
@@ -27,8 +28,7 @@ export function drawHighlightRings(
     theme: FullTheme
 ): (() => void) | undefined {
     const highlightRegions = allHighlightRegions?.filter(x => x.style !== "no-outline");
-    const freezeLeftColumns = typeof freezeColumns === "number" ? freezeColumns : freezeColumns[0];
-    const freezeRightColumns = typeof freezeColumns === "number" ? 0 : freezeColumns[1];
+    const [freezeLeftColumns, freezeRightColumns] = normalizeFreezeColumns(freezeColumns);
 
     if (highlightRegions === undefined || highlightRegions.length === 0) return undefined;
 

--- a/packages/core/src/internal/data-grid/render/data-grid.render.rings.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid.render.rings.ts
@@ -17,7 +17,7 @@ export function drawHighlightRings(
     translateX: number,
     translateY: number,
     mappedColumns: readonly MappedGridColumn[],
-    freezeColumns: number | [left: number, right: number],
+    freezeColumns: number | readonly [left: number, right: number],
     headerHeight: number,
     groupHeaderHeight: number,
     rowHeight: number | ((index: number) => number),
@@ -69,22 +69,22 @@ export function drawHighlightRings(
                 rect.width === 1 && rect.height === 1
                     ? topLeftBounds
                     : computeBounds(
-                        rect.x + rect.width - 1,
-                        rect.y + rect.height - 1,
-                        width,
-                        height,
-                        groupHeaderHeight,
-                        headerHeight + groupHeaderHeight,
-                        cellXOffset,
-                        cellYOffset,
-                        translateX,
-                        translateY,
-                        rows,
-                        freezeColumns,
-                        freezeTrailingRows,
-                        mappedColumns,
-                        rowHeight
-                    );
+                          rect.x + rect.width - 1,
+                          rect.y + rect.height - 1,
+                          width,
+                          height,
+                          groupHeaderHeight,
+                          headerHeight + groupHeaderHeight,
+                          cellXOffset,
+                          cellYOffset,
+                          translateX,
+                          translateY,
+                          rows,
+                          freezeColumns,
+                          freezeTrailingRows,
+                          mappedColumns,
+                          rowHeight
+                      );
 
             if (rect.x + rect.width >= mappedColumns.length) {
                 bottomRightBounds.width -= 1;

--- a/packages/core/src/internal/data-grid/render/data-grid.render.rings.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid.render.rings.ts
@@ -17,7 +17,7 @@ export function drawHighlightRings(
     translateX: number,
     translateY: number,
     mappedColumns: readonly MappedGridColumn[],
-    freezeColumns: number,
+    freezeColumns: number | [left: number, right: number],
     headerHeight: number,
     groupHeaderHeight: number,
     rowHeight: number | ((index: number) => number),
@@ -27,19 +27,21 @@ export function drawHighlightRings(
     theme: FullTheme
 ): (() => void) | undefined {
     const highlightRegions = allHighlightRegions?.filter(x => x.style !== "no-outline");
+    const freezeLeftColumns = typeof freezeColumns === "number" ? freezeColumns : freezeColumns[0];
+    const freezeRightColumns = typeof freezeColumns === "number" ? 0 : freezeColumns[1];
 
     if (highlightRegions === undefined || highlightRegions.length === 0) return undefined;
 
-    const freezeLeft = getStickyWidth(mappedColumns);
+    const [freezeLeft, freezeRight] = getStickyWidth(mappedColumns);
     const freezeBottom = getFreezeTrailingHeight(rows, freezeTrailingRows, rowHeight);
-    const splitIndicies = [freezeColumns, 0, mappedColumns.length, rows - freezeTrailingRows] as const;
+    const splitIndices = [freezeLeftColumns, 0, mappedColumns.length, rows - freezeTrailingRows] as const;
     const splitLocations = [freezeLeft, 0, width, height - freezeBottom] as const;
 
     const drawRects = highlightRegions.map(h => {
         const r = h.range;
         const style = h.style ?? "dashed";
 
-        return splitRectIntoRegions(r, splitIndicies, width, height, splitLocations).map(arg => {
+        return splitRectIntoRegions(r, splitIndices, width, height, splitLocations).map(arg => {
             const rect = arg.rect;
             const topLeftBounds = computeBounds(
                 rect.x,
@@ -187,6 +189,7 @@ export function drawFillHandle(
     getRowHeight: (row: number) => number,
     getCellContent: (cell: Item) => InnerGridCell,
     freezeTrailingRows: number,
+    freezeTrailingColumns: number,
     hasAppendRow: boolean,
     fillHandle: FillHandle,
     rows: number
@@ -223,10 +226,12 @@ export function drawFillHandle(
 
     walkColumns(
         effectiveCols,
+        width,
         cellYOffset,
         translateX,
         translateY,
         totalHeaderHeight,
+        freezeTrailingColumns,
         (col, drawX, colDrawY, clipX, startRow) => {
             clipX;
             if (col.sticky && targetCol > col.sourceIndex) return;

--- a/packages/core/src/internal/data-grid/render/draw-grid-arg.ts
+++ b/packages/core/src/internal/data-grid/render/draw-grid-arg.ts
@@ -40,7 +40,7 @@ export interface DrawGridArg {
     readonly translateY: number;
     readonly mappedColumns: readonly MappedGridColumn[];
     readonly enableGroups: boolean;
-    readonly freezeColumns: number | [left: number, right: number];
+    readonly freezeColumns: number | readonly [left: number, right: number];
     readonly dragAndDropState: DragAndDropState | undefined;
     readonly theme: FullTheme;
     readonly headerHeight: number;

--- a/packages/core/src/internal/data-grid/render/draw-grid-arg.ts
+++ b/packages/core/src/internal/data-grid/render/draw-grid-arg.ts
@@ -40,7 +40,7 @@ export interface DrawGridArg {
     readonly translateY: number;
     readonly mappedColumns: readonly MappedGridColumn[];
     readonly enableGroups: boolean;
-    readonly freezeColumns: number;
+    readonly freezeColumns: number | [left: number, right: number];
     readonly dragAndDropState: DragAndDropState | undefined;
     readonly theme: FullTheme;
     readonly headerHeight: number;

--- a/packages/core/src/internal/scrolling-data-grid/scrolling-data-grid.tsx
+++ b/packages/core/src/internal/scrolling-data-grid/scrolling-data-grid.tsx
@@ -103,7 +103,6 @@ const GridScroller: React.FunctionComponent<ScrollingDataGridProps> = p => {
     const lastSize = React.useRef<readonly [number, number] | undefined>();
 
     const freezeLeftColumns = typeof freezeColumns === "number" ? freezeColumns : freezeColumns[0];
-    const freezeRightColumns = typeof freezeColumns === "number"? 0 : freezeColumns[1];
 
     const width = nonGrowWidth + Math.max(0, overscrollX ?? 0);
 
@@ -222,14 +221,7 @@ const GridScroller: React.FunctionComponent<ScrollingDataGridProps> = p => {
             args.width !== lastSize.current?.[0] ||
             args.height !== lastSize.current?.[1]
         ) {
-            onVisibleRegionChanged?.(
-                rect,
-                args.width,
-                args.height,
-                args.paddingRight ?? 0,
-                tx,
-                ty
-            );
+            onVisibleRegionChanged?.(rect, args.width, args.height, args.paddingRight ?? 0, tx, ty);
             last.current = rect;
             lastX.current = tx;
             lastY.current = ty;

--- a/packages/core/src/internal/scrolling-data-grid/scrolling-data-grid.tsx
+++ b/packages/core/src/internal/scrolling-data-grid/scrolling-data-grid.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import DataGridDnd, { type DataGridDndProps } from "../data-grid-dnd/data-grid-dnd.js";
 import type { Rectangle } from "../data-grid/data-grid-types.js";
 import { InfiniteScroller } from "./infinite-scroller.js";
+import { normalizeFreezeColumns } from "../../common/utils.js";
 
 type Props = Omit<DataGridDndProps, "width" | "height" | "eventTargetRef">;
 
@@ -102,7 +103,7 @@ const GridScroller: React.FunctionComponent<ScrollingDataGridProps> = p => {
     const lastY = React.useRef<number | undefined>();
     const lastSize = React.useRef<readonly [number, number] | undefined>();
 
-    const freezeLeftColumns = typeof freezeColumns === "number" ? freezeColumns : freezeColumns[0];
+    const [freezeLeftColumns] = normalizeFreezeColumns(freezeColumns);
 
     const width = nonGrowWidth + Math.max(0, overscrollX ?? 0);
 

--- a/packages/core/src/internal/scrolling-data-grid/scrolling-data-grid.tsx
+++ b/packages/core/src/internal/scrolling-data-grid/scrolling-data-grid.tsx
@@ -102,6 +102,9 @@ const GridScroller: React.FunctionComponent<ScrollingDataGridProps> = p => {
     const lastY = React.useRef<number | undefined>();
     const lastSize = React.useRef<readonly [number, number] | undefined>();
 
+    const freezeLeftColumns = typeof freezeColumns === "number" ? freezeColumns : freezeColumns[0];
+    const freezeRightColumns = typeof freezeColumns === "number"? 0 : freezeColumns[1];
+
     const width = nonGrowWidth + Math.max(0, overscrollX ?? 0);
 
     let height = enableGroups ? headerHeight + groupHeaderHeight : headerHeight;
@@ -130,7 +133,7 @@ const GridScroller: React.FunctionComponent<ScrollingDataGridProps> = p => {
         args.x = args.x < 0 ? 0 : args.x;
 
         let stickyColWidth = 0;
-        for (let i = 0; i < freezeColumns; i++) {
+        for (let i = 0; i < freezeLeftColumns; i++) {
             stickyColWidth += columns[i].width;
         }
 
@@ -220,12 +223,7 @@ const GridScroller: React.FunctionComponent<ScrollingDataGridProps> = p => {
             args.height !== lastSize.current?.[1]
         ) {
             onVisibleRegionChanged?.(
-                {
-                    x: cellX,
-                    y: cellY,
-                    width: cellRight - cellX,
-                    height: cellBottom - cellY,
-                },
+                rect,
                 args.width,
                 args.height,
                 args.paddingRight ?? 0,
@@ -237,7 +235,7 @@ const GridScroller: React.FunctionComponent<ScrollingDataGridProps> = p => {
             lastY.current = ty;
             lastSize.current = [args.width, args.height];
         }
-    }, [columns, rowHeight, rows, onVisibleRegionChanged, freezeColumns, smoothScrollX, smoothScrollY]);
+    }, [columns, rowHeight, rows, onVisibleRegionChanged, freezeLeftColumns, smoothScrollX, smoothScrollY]);
 
     const onScrollUpdate = React.useCallback(
         (args: Rectangle & { paddingRight: number }) => {

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -2273,6 +2273,53 @@ describe("data-editor", () => {
         );
     });
 
+
+    test("Freeze area reported with right freeze included", async () => {
+        const spy = vi.fn();
+        vi.useFakeTimers();
+        render(
+            <EventedDataEditor {...basicProps} freezeColumns={[2, 2]} onVisibleRegionChanged={spy} />,
+            {
+                wrapper: Context,
+            }
+        );
+        prep();
+
+        expect(spy).toBeCalledWith(
+            expect.objectContaining({
+                height: 32,
+                width: 9,
+                x: 2,
+                y: 0,
+            }),
+            0,
+            0,
+            expect.objectContaining({
+                freezeRegion: {
+                    height: 32,
+                    width: 2,
+                    x: 0,
+                    y: 0,
+                },
+                freezeRegions: [
+                    {
+                        height: 32,
+                        width: 2,
+                        x: 0,
+                        y: 0,
+                    },
+                    {
+                        height: 32,
+                        width: 2,
+                        x: 9,
+                        y: 0,
+                    },
+                ],
+                selected: undefined,
+            })
+        );
+    });
+
     test("Search close", async () => {
         const spy = vi.fn();
         vi.useFakeTimers();

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -196,6 +196,53 @@ describe("data-editor", () => {
         expect(spySelection).not.toHaveBeenCalled();
     });
 
+    test("opens contextmenu at selected cell position when fired on canvas", async () => {
+      const spy = vi.fn();
+
+      vi.useFakeTimers();
+      render(<DataEditor
+        {...basicProps}
+        gridSelection={{
+          columns: CompactSelection.empty(),
+          rows: CompactSelection.empty(),
+          current: {
+            cell: [1, 1],
+            range: { x: 1, y: 1, width: 1, height: 1 },
+            rangeStack: [],
+          },
+        }}
+        onCellContextMenu={spy}
+      />, { wrapper: Context });
+
+      prep();
+
+      const canvas = screen.getByTestId("data-grid-canvas");
+
+      fireEvent.contextMenu(canvas);
+
+      expect(spy).toHaveBeenCalledWith([1, 1], expect.anything());
+    });
+
+    test("does not open contextmenu when no cell selected", async () => {
+      const spy = vi.fn();
+
+      vi.useFakeTimers();
+      render(<DataEditor
+        {...basicProps}
+        gridSelection={{
+          columns: CompactSelection.empty(),
+          rows: CompactSelection.empty(),
+        }}
+        onCellContextMenu={spy}
+      />, { wrapper: Context });
+
+      prep();
+      const canvas = screen.getByTestId("data-grid-canvas");
+      fireEvent.contextMenu(canvas);
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
     test("middle click does not change selection", async () => {
         const spySelection = vi.fn();
 

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -705,6 +705,34 @@ describe("data-editor", () => {
         expect(spy).toHaveBeenCalledWith([1, 1], expect.anything());
     });
 
+    test("Emits activated event when typing on a frozen column outside the tracked scroll region", async () => {
+        const spy = vi.fn();
+
+        vi.useFakeTimers();
+        render(<DataEditor {...basicProps} freezeColumns={2} onCellActivated={spy} />, {
+            wrapper: Context,
+        });
+        prep(false);
+
+        const canvas = screen.getByTestId("data-grid-canvas");
+        const [x, y] = getCellCenterPositionForDefaultGrid([1, 1]);
+        sendClick(canvas, {
+            clientX: x, // Col B, frozen (freezeColumns=2 covers cols 0 and 1)
+            clientY: y,
+        });
+
+        fireEvent.keyDown(canvas, {
+            key: "A",
+        });
+
+        act(() => {
+            vi.runAllTimers();
+        });
+
+        expect(spy).toHaveBeenCalled();
+        expect(spy).toHaveBeenCalledWith([1, 1], expect.anything());
+    });
+
     test("keyDown and keyUp events include the cell location", async () => {
         let keyDownEvent: GridKeyEventArgs | undefined;
         let keyUpEvent: GridKeyEventArgs | undefined;

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -1183,10 +1183,10 @@ describe("data-editor", () => {
           width: expect.any(Number),
           height: expect.any(Number),
         }),
+        localEventX: eventArgs.bounds.width / 2,
+        localEventY: eventArgs.bounds.height / 2,
       });
 
-      expect(eventArgs.localEventX).toBe(eventArgs.bounds.width / 2);
-      expect(eventArgs.localEventY).toBe(eventArgs.bounds.height / 2);
     });
 
     test("does not open context menu with Shift+F10 when no cells are selected", async () => {
@@ -1211,6 +1211,7 @@ describe("data-editor", () => {
 
       const canvas = screen.getByTestId("data-grid-canvas");
 
+      // Press Shift+F10 without selecting any cell
       fireEvent.keyDown(canvas, {
         key: "F10",
         keyCode: 121,

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -196,53 +196,6 @@ describe("data-editor", () => {
         expect(spySelection).not.toHaveBeenCalled();
     });
 
-    test("opens contextmenu at selected cell position when fired on canvas", async () => {
-      const spy = vi.fn();
-
-      vi.useFakeTimers();
-      render(<DataEditor
-        {...basicProps}
-        gridSelection={{
-          columns: CompactSelection.empty(),
-          rows: CompactSelection.empty(),
-          current: {
-            cell: [1, 1],
-            range: { x: 1, y: 1, width: 1, height: 1 },
-            rangeStack: [],
-          },
-        }}
-        onCellContextMenu={spy}
-      />, { wrapper: Context });
-
-      prep();
-
-      const canvas = screen.getByTestId("data-grid-canvas");
-
-      fireEvent.contextMenu(canvas);
-
-      expect(spy).toHaveBeenCalledWith([1, 1], expect.anything());
-    });
-
-    test("does not open contextmenu when no cell selected", async () => {
-      const spy = vi.fn();
-
-      vi.useFakeTimers();
-      render(<DataEditor
-        {...basicProps}
-        gridSelection={{
-          columns: CompactSelection.empty(),
-          rows: CompactSelection.empty(),
-        }}
-        onCellContextMenu={spy}
-      />, { wrapper: Context });
-
-      prep();
-      const canvas = screen.getByTestId("data-grid-canvas");
-      fireEvent.contextMenu(canvas);
-
-      expect(spy).not.toHaveBeenCalled();
-    });
-
     test("middle click does not change selection", async () => {
         const spySelection = vi.fn();
 
@@ -1194,6 +1147,77 @@ describe("data-editor", () => {
 
         expect(spy).toHaveBeenCalled();
         expect(spy).toHaveBeenCalledWith(expect.objectContaining({ location: [1, 1] }));
+    });
+
+    test("opens context menu with Shift+F10 when cell is selected", async () => {
+      const spy = vi.fn();
+
+      vi.useFakeTimers();
+      render(<DataEditor {...basicProps} onCellContextMenu={spy} />, {
+        wrapper: Context,
+      });
+      prep(false);
+
+      const canvas = screen.getByTestId("data-grid-canvas");
+      sendClick(canvas, {
+        clientX: 300,
+        clientY: 84,
+      });
+
+      fireEvent.keyDown(canvas, {
+        key: "F10",
+        keyCode: 121,
+        shiftKey: true,
+      });
+
+      expect(spy).toHaveBeenCalledWith([1, 1], expect.anything());
+
+      const eventArgs = spy.mock.calls[0][1];
+      expect(eventArgs).toMatchObject({
+        kind: "cell",
+        shiftKey: true,
+        location: [1, 1],
+        bounds: expect.objectContaining({
+          x: expect.any(Number),
+          y: expect.any(Number),
+          width: expect.any(Number),
+          height: expect.any(Number),
+        }),
+      });
+
+      expect(eventArgs.localEventX).toBe(eventArgs.bounds.width / 2);
+      expect(eventArgs.localEventY).toBe(eventArgs.bounds.height / 2);
+    });
+
+    test("does not open context menu with Shift+F10 when no cells are selected", async () => {
+      const spy = vi.fn();
+
+      vi.useFakeTimers();
+      render(
+        <DataEditor
+          {...basicProps}
+          onCellContextMenu={spy}
+          gridSelection={{
+            columns: CompactSelection.empty(),
+            rows: CompactSelection.empty(),
+            current: undefined,
+          }}
+        />,
+        {
+          wrapper: Context,
+        }
+      );
+      prep(false);
+
+      const canvas = screen.getByTestId("data-grid-canvas");
+
+      fireEvent.keyDown(canvas, {
+        key: "F10",
+        keyCode: 121,
+        shiftKey: true,
+      });
+
+      expect(spy).not.toHaveBeenCalled();
     });
 
     test("Delete cell", async () => {

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -3830,6 +3830,49 @@ describe("data-editor", () => {
         });
     });
 
+    test("Span in frozen trailing row repaints fill per column (no bleed)", async () => {
+        // Regression: with a spanning cell in a frozen trailing row, every column must
+        // paint its own fill so scrolling-row overflow at freezeY is overwritten per
+        // column — not just once by the first column that hit the span.
+        vi.useFakeTimers();
+
+        const rowHeight = basicProps.rowHeight as number;
+        const spannedRow = basicProps.rows - 1;
+        const getCellContent: (typeof basicProps)["getCellContent"] = c => {
+            if (c[1] === spannedRow) {
+                return {
+                    ...basicProps.getCellContent([0, spannedRow]),
+                    span: [0, basicProps.columns.length - 1] as const,
+                };
+            }
+            return basicProps.getCellContent(c);
+        };
+
+        render(
+            <EventedDataEditor
+                {...basicProps}
+                getCellContent={getCellContent}
+                freezeTrailingRows={1}
+                trailingRowOptions={undefined}
+            />,
+            { wrapper: Context }
+        );
+        prep(false);
+
+        const canvas = screen.getByTestId("data-grid-canvas") as HTMLCanvasElement;
+        const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
+        const frozenY = canvas.height - rowHeight;
+        const fillRectMock = ctx.fillRect as unknown as Mock;
+        // ±2px tolerates the damage-path +1 inset. h === rowHeight distinguishes row
+        // fills from cell decoration draws.
+        const frozenRowFills = fillRectMock.mock.calls.filter(
+            ([, y, , h]) => typeof y === "number" && Math.abs(y - frozenY) <= 2 && h === rowHeight
+        );
+
+        // Without the fix: 1 wide fill (first column only). With it: 1 wide + N-1 per-column.
+        expect(frozenRowFills.length).toBeGreaterThan(1);
+    });
+
     test("Imperative scrollTo false fire", async () => {
         vi.useFakeTimers();
         const ref = React.createRef<DataEditorRef>();

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -2689,7 +2689,10 @@ describe("data-editor", () => {
             }
         );
         prep();
-        expect(spy).toHaveBeenCalledTimes(31); // Math.ceil((height - headerHeight) / rowHeight)
+        // basicProps sets a sticky trailingRowOptions row, which reserves one rowHeight of space
+        // at the bottom of the canvas for that frozen row. The scrollable rows above it stop at
+        // that boundary rather than at the raw canvas height.
+        expect(spy).toHaveBeenCalledTimes(30); // Math.ceil((height - rowHeight - headerHeight) / rowHeight)
     });
 
     test("onCellsEdited blocks onCellEdited", async () => {
@@ -3830,10 +3833,12 @@ describe("data-editor", () => {
         });
     });
 
-    test("Span in frozen trailing row repaints fill per column (no bleed)", async () => {
-        // Regression: with a spanning cell in a frozen trailing row, every column must
-        // paint its own fill so scrolling-row overflow at freezeY is overwritten per
-        // column — not just once by the first column that hit the span.
+    test("Span in frozen trailing row draws full-width content once (no per-column overpaint)", async () => {
+        // Regression: a spanning cell in a frozen trailing row must be painted once at full width
+        // by the first column that hits it. The previous behavior repainted each column's own fill
+        // over the band (to cover scrolling-row overflow into the freeze band), which overpainted
+        // the wide span content and truncated it. Scrolling rows are now kept out of the freeze
+        // band instead, so the single wide fill survives and no narrow per-column fill lands there.
         vi.useFakeTimers();
 
         const rowHeight = basicProps.rowHeight as number;
@@ -3863,14 +3868,16 @@ describe("data-editor", () => {
         const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
         const frozenY = canvas.height - rowHeight;
         const fillRectMock = ctx.fillRect as unknown as Mock;
-        // ±2px tolerates the damage-path +1 inset. h === rowHeight distinguishes row
-        // fills from cell decoration draws.
-        const frozenRowFills = fillRectMock.mock.calls.filter(
+        // Full-redraw row fills at the frozen band. h === rowHeight distinguishes them from the
+        // damage-path (inset) fills and from cell-decoration draws.
+        const bandFills = fillRectMock.mock.calls.filter(
             ([, y, , h]) => typeof y === "number" && Math.abs(y - frozenY) <= 2 && h === rowHeight
         );
 
-        // Without the fix: 1 wide fill (first column only). With it: 1 wide + N-1 per-column.
-        expect(frozenRowFills.length).toBeGreaterThan(1);
+        // The span is filled once across the whole grid, far wider than any single column.
+        expect(bandFills.some(([, , w]) => typeof w === "number" && w > 500)).toBe(true);
+        // No column repaints its own narrow slice over the band — that overpaint truncated the span.
+        expect(bandFills.some(([, , w]) => typeof w === "number" && w < 300)).toBe(false);
     });
 
     test("Imperative scrollTo false fire", async () => {

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -3949,6 +3949,49 @@ describe("data-editor", () => {
         });
     });
 
+    test("Span in frozen trailing row repaints fill per column (no bleed)", async () => {
+        // Regression: with a spanning cell in a frozen trailing row, every column must
+        // paint its own fill so scrolling-row overflow at freezeY is overwritten per
+        // column — not just once by the first column that hit the span.
+        vi.useFakeTimers();
+
+        const rowHeight = basicProps.rowHeight as number;
+        const spannedRow = basicProps.rows - 1;
+        const getCellContent: (typeof basicProps)["getCellContent"] = c => {
+            if (c[1] === spannedRow) {
+                return {
+                    ...basicProps.getCellContent([0, spannedRow]),
+                    span: [0, basicProps.columns.length - 1] as const,
+                };
+            }
+            return basicProps.getCellContent(c);
+        };
+
+        render(
+            <EventedDataEditor
+                {...basicProps}
+                getCellContent={getCellContent}
+                freezeTrailingRows={1}
+                trailingRowOptions={undefined}
+            />,
+            { wrapper: Context }
+        );
+        prep(false);
+
+        const canvas = screen.getByTestId("data-grid-canvas") as HTMLCanvasElement;
+        const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
+        const frozenY = canvas.height - rowHeight;
+        const fillRectMock = ctx.fillRect as unknown as Mock;
+        // ±2px tolerates the damage-path +1 inset. h === rowHeight distinguishes row
+        // fills from cell decoration draws.
+        const frozenRowFills = fillRectMock.mock.calls.filter(
+            ([, y, , h]) => typeof y === "number" && Math.abs(y - frozenY) <= 2 && h === rowHeight
+        );
+
+        // Without the fix: 1 wide fill (first column only). With it: 1 wide + N-1 per-column.
+        expect(frozenRowFills.length).toBeGreaterThan(1);
+    });
+
     test("Imperative scrollTo false fire", async () => {
         vi.useFakeTimers();
         const ref = React.createRef<DataEditorRef>();

--- a/packages/core/test/data-grid.test.tsx
+++ b/packages/core/test/data-grid.test.tsx
@@ -395,4 +395,71 @@ describe("data-grid", () => {
             false
         );
     });
+
+    test("Freeze column simple check with trailing", () => {
+        const spy = vi.fn();
+
+        const basicPropsWithMoreColumns = {
+            ...basicProps,
+            columns: [
+                ...basicProps.columns,
+                {
+                    title: "F",
+                    width: 150,
+                },
+                {
+                    title: "G",
+                    width: 150,
+                },
+                {
+                    title: "H",
+                    width: 150,
+                },
+                {
+                    title: "I",
+                    width: 150,
+                },
+                {
+                    title: "J",
+                    width: 150,
+                },
+                {
+                    title: "K",
+                    width: 150,
+                },
+                {
+                    title: "L",
+                    width: 150,
+                },
+            ],
+        };
+
+        render(<DataGrid {...basicPropsWithMoreColumns} freezeColumns={[1, 1]} cellXOffset={3} onMouseUp={spy} />);
+
+
+        fireEvent.mouseDown(screen.getByTestId(dataGridCanvasId), {
+            clientX: 950, // Col A
+            clientY: 36 + 32 * 5 + 16, // Row 5 (0 indexed)
+        });
+
+        fireEvent.mouseUp(screen.getByTestId(dataGridCanvasId), {
+            clientX: 950, // Col A
+            clientY: 36 + 32 * 5 + 16, // Row 5 (0 indexed)
+        });
+
+        fireEvent.click(screen.getByTestId(dataGridCanvasId), {
+            clientX: 950, // Col A
+            clientY: 36 + 32 * 5 + 16, // Row 5 (0 indexed)
+        });
+
+        expect(spy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                location: [11, 5],
+                kind: "cell",
+                localEventX: 100,
+                localEventY: 16,
+            }),
+            false
+        );
+    });
 });

--- a/packages/core/test/data-grid.test.tsx
+++ b/packages/core/test/data-grid.test.tsx
@@ -437,12 +437,12 @@ describe("data-grid", () => {
         render(<DataGrid {...basicPropsWithMoreColumns} freezeColumns={[1, 1]} cellXOffset={3} onMouseUp={spy} />);
 
 
-        fireEvent.mouseDown(screen.getByTestId(dataGridCanvasId), {
+        fireEvent.pointerDown(screen.getByTestId(dataGridCanvasId), {
             clientX: 950, // Col A
             clientY: 36 + 32 * 5 + 16, // Row 5 (0 indexed)
         });
 
-        fireEvent.mouseUp(screen.getByTestId(dataGridCanvasId), {
+        fireEvent.pointerUp(screen.getByTestId(dataGridCanvasId), {
             clientX: 950, // Col A
             clientY: 36 + 32 * 5 + 16, // Row 5 (0 indexed)
         });

--- a/packages/core/test/image-window-loader.test.ts
+++ b/packages/core/test/image-window-loader.test.ts
@@ -19,11 +19,26 @@ describe("ImageWindowLoaderImpl", () => {
             };
             const freezeCols = 5;
 
-            loader.setWindow(newWindow, freezeCols, []);
+            loader.setWindow(newWindow, freezeCols, [], 10);
 
             // Assuming you modify your class to expose `visibleWindow` and `freezeCols` for testing
             expect(loader.visibleWindow).toEqual(newWindow);
             expect(loader.freezeCols).toBe(freezeCols);
+        });
+
+        it("should set the new columnsLength", () => {
+            const newWindow = {
+                x: 10,
+                y: 10,
+                width: 100,
+                height: 100,
+            };
+            const freezeCols = 5;
+            const columnsLength = 10;
+
+            loader.setWindow(newWindow, freezeCols, [], columnsLength);
+
+            expect(loader.columnsLength).toBe(columnsLength);
         });
 
         it("should call clearOutOfWindow() if the window or freezeCols changes", () => {
@@ -44,13 +59,13 @@ describe("ImageWindowLoaderImpl", () => {
             const freezeCols1 = 5;
             const freezeCols2 = 10;
 
-            loader.setWindow(window1, freezeCols1, []);
+            loader.setWindow(window1, freezeCols1, [], 10);
             expect(spyClearOutOfWindow).toHaveBeenCalledTimes(1);
 
-            loader.setWindow(window2, freezeCols1, []);
+            loader.setWindow(window2, freezeCols1, [], 10);
             expect(spyClearOutOfWindow).toHaveBeenCalledTimes(2);
 
-            loader.setWindow(window2, freezeCols2, []);
+            loader.setWindow(window2, freezeCols2, [], 10);
             expect(spyClearOutOfWindow).toHaveBeenCalledTimes(3);
 
             // Cleanup
@@ -68,8 +83,8 @@ describe("ImageWindowLoaderImpl", () => {
             };
             const freezeCols = 5;
 
-            loader.setWindow(newWindow, freezeCols, []);
-            loader.setWindow(newWindow, freezeCols, []);
+            loader.setWindow(newWindow, freezeCols, [], 10);
+            loader.setWindow(newWindow, freezeCols, [], 10);
 
             expect(spyClearOutOfWindow).toHaveBeenCalledTimes(1);
 

--- a/packages/core/test/render-state-provider.test.ts
+++ b/packages/core/test/render-state-provider.test.ts
@@ -78,7 +78,7 @@ describe("Data Grid Utility Functions", () => {
         it("should update visible window and freeze columns correctly", () => {
             renderStateProvider.setValue([0, 30], "state");
             renderStateProvider.setValue([1, 0], "state");
-            renderStateProvider.setWindow(testRectangle, 1, []);
+            renderStateProvider.setWindow(testRectangle, 1, [], 10);
             expect(renderStateProvider.getValue([0, 30])).to.equal("state");
             expect(renderStateProvider.getValue([1, 0])).to.equal(undefined);
         });

--- a/packages/source/src/use-collapsing-groups.ts
+++ b/packages/source/src/use-collapsing-groups.ts
@@ -34,7 +34,7 @@ export function useCollapsingGroups(props: Props): Result {
         const result: [number, number][] = [];
         let current: [number, number] = [-1, -1];
         let lastGroup: string | undefined;
-        for (let i = freezeColumnsLeft as number; i < columnsIn.length - freezeColumnsRight; i++) {
+        for (let i = freezeColumnsLeft; i < columnsIn.length - freezeColumnsRight; i++) {
             const c = columnsIn[i];
             const group = c.group ?? "";
             const isCollapsed = collapsed.includes(group);
@@ -121,8 +121,8 @@ export function useCollapsingGroups(props: Props): Result {
                 name: group,
                 overrideTheme: collapsed.includes(group ?? "")
                     ? {
-                        bgHeader: theme.bgHeaderHasFocus,
-                    }
+                          bgHeader: theme.bgHeaderHasFocus,
+                      }
                     : undefined,
             };
         },

--- a/packages/source/src/use-collapsing-groups.ts
+++ b/packages/source/src/use-collapsing-groups.ts
@@ -25,13 +25,16 @@ export function useCollapsingGroups(props: Props): Result {
         theme,
     } = props;
 
+    const freezeColumnsLeft = typeof freezeColumns === "number" ? freezeColumns : freezeColumns[0];
+    const freezeColumnsRight = typeof freezeColumns === "number" ? 0 : freezeColumns[1];
+
     const gridSelection = gridSelectionIn ?? gridSelectionInner;
 
     const spans = React.useMemo(() => {
         const result: [number, number][] = [];
         let current: [number, number] = [-1, -1];
         let lastGroup: string | undefined;
-        for (let i = freezeColumns; i < columnsIn.length; i++) {
+        for (let i = freezeColumnsLeft as number; i < columnsIn.length - freezeColumnsRight; i++) {
             const c = columnsIn[i];
             const group = c.group ?? "";
             const isCollapsed = collapsed.includes(group);
@@ -53,7 +56,7 @@ export function useCollapsingGroups(props: Props): Result {
         }
         if (current[0] !== -1) result.push(current);
         return result;
-    }, [collapsed, columnsIn, freezeColumns]);
+    }, [collapsed, columnsIn, freezeColumnsLeft, freezeColumnsRight]);
 
     const columns = React.useMemo(() => {
         if (spans.length === 0) return columnsIn;
@@ -118,8 +121,8 @@ export function useCollapsingGroups(props: Props): Result {
                 name: group,
                 overrideTheme: collapsed.includes(group ?? "")
                     ? {
-                          bgHeader: theme.bgHeaderHasFocus,
-                      }
+                        bgHeader: theme.bgHeaderHasFocus,
+                    }
                     : undefined,
             };
         },


### PR DESCRIPTION
##  Problem

  The grid's ideal-height calculation always reserved vertical space for a horizontal scrollbar, even when the content didn't actually overflow horizontally — leaving dead space below the grid in the
  common case where everything fits.

  For variable row heights (rowHeight as a function), the estimate also averaged only the first 10 rows and extrapolated that average across the entire dataset. On large, heterogeneous datasets this
  could be significantly off, producing an incorrect ideal height and, ironically, a spurious scrollbar of its own.

##  Change

  - Extracted the ideal-size calculation out of data-editor.tsx into a pure, exported computeIdealSize function in data-editor-fns.ts so it's unit-testable in isolation.
  - Horizontal-scrollbar height is now only reserved when contentWidth > clientAreaWidth (i.e. the content actually overflows horizontally), removing the dead space in the non-overflowing case.
  - For function-based rowHeight, once the client area has been measured, the new logic sums exact row heights until the viewport is filled (with a minimum 10-row floor so the average isn't based on a
    single outlier row), then extrapolates the remainder from that average — instead of always averaging just the first 10 rows regardless of dataset size. This stays O(1)-ish for huge datasets while
    being far more accurate than the old fixed 10-row average.
  - Before the client area has been measured (first render), it still falls back to the bounded 10-row sample average, as before.
  - Memoized clientAreaWidth/clientAreaHeight as primitives out of clientSize so the idealWidth/idealHeight useMemo doesn't re-run on every scroll tick just because clientSize got a new array reference.
